### PR TITLE
Introduce shared BookshelfView and separate MyBookshelf/PublicBookshelf

### DIFF
--- a/frontend/src/api/bookshelves.ts
+++ b/frontend/src/api/bookshelves.ts
@@ -37,6 +37,26 @@ export async function createBookshelf(
   return json.data;
 }
 
+export async function getBookshelfById(id: string): Promise<Bookshelf | null> {
+  const response = await fetch(`${API_URL}/bookshelves/${id}`, {
+    headers: {
+      "X-API-KEY": API_KEY,
+    },
+  });
+
+  const json: ApiResponse<Bookshelf> = await response.json();
+
+  if (json.error) {
+    throw new Error(json.error.message);
+  }
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch bookshelf");
+  }
+
+  return json.data;
+}
+
 export async function getBookshelfByToken(
   token: string,
 ): Promise<Bookshelf | null> {
@@ -54,6 +74,28 @@ export async function getBookshelfByToken(
 
   if (!response.ok) {
     throw new Error("Failed to fetch bookshelf");
+  }
+
+  return json.data;
+}
+
+export async function getBooksInBookshelfById(
+  id: string,
+): Promise<Book[] | null> {
+  const response = await fetch(`${API_URL}/bookshelves/${id}/books`, {
+    headers: {
+      "X-API-KEY": API_KEY,
+    },
+  });
+
+  const json: ApiResponse<Book[]> = await response.json();
+
+  if (json.error) {
+    throw new Error(json.error.message);
+  }
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch books in bookshelf");
   }
 
   return json.data;

--- a/frontend/src/components/commons/BookshelfVeiw.tsx
+++ b/frontend/src/components/commons/BookshelfVeiw.tsx
@@ -1,0 +1,71 @@
+import { type FC } from "react";
+import { Button } from "./Button";
+import { useLanguage } from "../../hooks/useLanguage";
+import type { Book } from "../../types/book";
+import type { Bookshelf } from "../../types/bookshelf";
+
+interface BookshelfViewProps {
+  bookshelf: Bookshelf;
+  books: Book[];
+  canEdit: boolean;
+}
+
+export const BookshelfView: FC<BookshelfViewProps> = ({
+  canEdit,
+  bookshelf,
+  books,
+}) => {
+  const { t } = useLanguage();
+  return (
+    <div className="w-full px-10">
+      <div className="max-w-3xl mx-auto py-10 px-4">
+        <div className="flex flex-col sm:flex-row justify-between items-center mb-6 gap-4">
+          <div className="text-center sm:text-left max-w-[70%]">
+            <h1 className="text-3xl font-bold text-gray-900">
+              {bookshelf.name}
+            </h1>
+            <p className="text-sm text-gray-700 mt-1">
+              ID: <span className="font-mono">{bookshelf.id}</span>
+            </p>
+            <p className="text-gray-700 mt-1">{bookshelf.description}</p>
+          </div>
+          {canEdit && (
+            <div className="flex flex-col gap-3">
+              <Button
+                label={t("button.addBook")}
+                onClick={() => {
+                  /* Handle add book action */
+                }}
+              />
+              <Button
+                label={t("button.deleteBookshelf")}
+                onClick={() => {
+                  /* Handle delete bookshelf action */
+                }}
+                color="danger"
+              />
+            </div>
+          )}
+        </div>
+        <hr className="border-gray-300 mb-4" />
+      </div>
+      <div>
+        <h2 className="text-2xl font-semibold text-gray-800 mb-2">
+          {t("bookshelfView.books")}
+        </h2>
+        {books.length === 0 ? (
+          <p>{t("bookshelfView.noBooks")}</p>
+        ) : (
+          <ul className="space-y-2">
+            {books.map((book) => (
+              <li key={book.id} className="border-b py-2">
+                <h3 className="font-semibold">{book.title}</h3>
+                <p className="text-sm text-gray-600">{book.author}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/commons/Button.tsx
+++ b/frontend/src/components/commons/Button.tsx
@@ -5,6 +5,7 @@ interface ButtonProps {
   onClick: () => void;
   disabled?: boolean;
   color?: "success" | "danger";
+  className?: string;
 }
 
 export const Button: FC<ButtonProps> = ({
@@ -12,6 +13,7 @@ export const Button: FC<ButtonProps> = ({
   onClick,
   disabled = false,
   color = "success",
+  className = "",
 }) => {
   const colorStyles = {
     success:
@@ -24,7 +26,7 @@ export const Button: FC<ButtonProps> = ({
       disabled={disabled}
       type="button"
       className={`${colorStyles[color]} px-4 py-2 text-shadow-lg rounded shadow-lg
-        ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+        ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"} ${className}`}
     >
       {label}
     </button>

--- a/frontend/src/components/commons/Topbar.tsx
+++ b/frontend/src/components/commons/Topbar.tsx
@@ -24,10 +24,17 @@ export const Topbar: FC = () => {
       <Link to="/" className="text-text text-2xl text-shadow-sm font-bold">
         {t("common.appName")}
       </Link>
-      <Button
-        label={t("button.openMyBookshelf")}
-        onClick={handleOpenBookshelf}
-      />
+      <div>
+        <Button
+          label={t("button.visitBookshelf")}
+          onClick={() => openModal("ENTER_ID", {})}
+          className="mr-4"
+        />
+        <Button
+          label={t("button.openMyBookshelf")}
+          onClick={handleOpenBookshelf}
+        />
+      </div>
     </nav>
   );
 };

--- a/frontend/src/components/modals/CreateBookshelfModal.tsx
+++ b/frontend/src/components/modals/CreateBookshelfModal.tsx
@@ -16,6 +16,8 @@ export const CreateBookshelfModal: FC = () => {
   const [description, setDescription] = useState("");
   const [nameTouched, setNameTouched] = useState(false);
   const [nameError, setNameError] = useState(false);
+  const [descriptionTouched, setDescriptionTouched] = useState(false);
+  const [descriptionError, setDescriptionError] = useState(false);
 
   const handleCreate = async () => {
     try {
@@ -27,10 +29,13 @@ export const CreateBookshelfModal: FC = () => {
         openModal("TOKEN", { token: newBookshelf.editToken });
       }
     } catch (error) {
-      setNameError(true);
-      toast.error(
-        error instanceof Error ? error.message : t("toast.anErrorOccurred"),
-      );
+      const message =
+        error instanceof Error ? error.message : t("toast.anErrorOccurred");
+      if (message.toLowerCase().includes("name")) setNameError(true);
+      if (message.toLowerCase().includes("description"))
+        setDescriptionError(true);
+
+      toast.error(message);
       console.error("Error creating bookshelf:", error);
     }
   };
@@ -68,6 +73,11 @@ export const CreateBookshelfModal: FC = () => {
             className={`w-full rounded-md  border ${(nameTouched && !name) || nameError ? "border-red-500" : "border-gray-300"} shadow-sm px-3 py-2 text-sm`}
             placeholder={t("modal.namePlaceholder")}
           />
+          <p
+            className={`text-xs ${name.length <= 100 ? "text-gray-400" : "text-red-400"} text-right`}
+          >
+            {name.length}/100
+          </p>
         </div>
         <div className="mb-4">
           <label className="block text-sm text-gray-800 text-shadow-sm mb-1">
@@ -76,10 +86,19 @@ export const CreateBookshelfModal: FC = () => {
           <textarea
             value={description}
             onChange={(e) => setDescription(e.target.value)}
-            className="w-full rounded-md  border border-gray-300 shadow-sm px-3 py-2 text-sm resize-none"
+            onBlur={() => {
+              setDescriptionError(false);
+              setDescriptionTouched(true);
+            }}
+            className={`w-full rounded-md  border ${(descriptionTouched && !description) || descriptionError ? "border-red-500" : "border-gray-300"} shadow-sm px-3 py-2 text-sm resize-none`}
             placeholder={t("modal.descriptionPlaceholder")}
             rows={3}
           />
+          <p
+            className={`text-xs ${description.length <= 1000 ? "text-gray-400" : "text-red-400"} text-right`}
+          >
+            {description.length}/1000
+          </p>
         </div>
         <div className="flex justify-end space-x-3">
           <Button
@@ -90,7 +109,7 @@ export const CreateBookshelfModal: FC = () => {
           <Button
             label={t("button.create")}
             onClick={() => handleCreate()}
-            disabled={!name || nameError}
+            disabled={!name || nameError || descriptionError}
           />
         </div>
       </div>

--- a/frontend/src/components/modals/EnterIdModal.tsx
+++ b/frontend/src/components/modals/EnterIdModal.tsx
@@ -1,0 +1,57 @@
+import { type FC, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { useLanguage } from "../../hooks/useLanguage";
+import { useModal } from "../../hooks/useModal";
+import { Button } from "../commons/Button";
+
+const isValidNumericId = (value: string) => /^[1-9]\d*$/.test(value.trim());
+
+export const EnterIdModal: FC = () => {
+  const { t } = useLanguage();
+  const { closeModal } = useModal();
+  const [id, setId] = useState("");
+  const navigate = useNavigate();
+
+  const handleSubmit = async () => {
+    const trimmedId = id.trim();
+    if (!isValidNumericId(trimmedId)) {
+      toast.error(t("toast.invalidBookshelfId"));
+      return;
+    }
+    if (trimmedId) {
+      navigate(`/bookshelves/${trimmedId}`);
+      closeModal();
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+      <div className="bg-white p-6 rounded-xl shadow-xl w-full max-w-md text-center">
+        <h2 className="text-xl font-semibold text-text text-shadow-sm mb-4">
+          {t("modal.enterIdToVisit")}
+        </h2>
+        <input
+          type="number"
+          min={1}
+          placeholder={t("modal.pasteIdHere")}
+          className="w-full p-2 border border-gray-300 rounded mb-4"
+          value={id}
+          onChange={(e) => setId(e.target.value)}
+        />
+        <div className="flex justify-end space-x-2">
+          <Button
+            label={t("button.cancel")}
+            onClick={() => closeModal()}
+            color="danger"
+          />
+          <Button
+            label={t("button.open")}
+            onClick={() => handleSubmit()}
+            disabled={!id.trim()}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/modals/ModalRoot.tsx
+++ b/frontend/src/components/modals/ModalRoot.tsx
@@ -1,5 +1,6 @@
 import { type FC } from "react";
 import { CreateBookshelfModal } from "./CreateBookshelfModal";
+import { EnterIdModal } from "./EnterIdModal";
 import { EnterTokenModal } from "./EnterTokenModal";
 import { ShowTokenModal } from "./ShowTokenModal";
 import { type ModalState } from "../../contexts/ModalContext";
@@ -21,6 +22,8 @@ export const ModalRoot: FC<ModalRootProps> = ({ modalState }) => {
       );
     case "ENTER_TOKEN":
       return <EnterTokenModal />;
+    case "ENTER_ID":
+      return <EnterIdModal />;
     case null:
       return null;
     default:

--- a/frontend/src/contexts/ModalContext.ts
+++ b/frontend/src/contexts/ModalContext.ts
@@ -1,12 +1,18 @@
 import { createContext } from "react";
 import type { EmptyObject } from "../types/emptyObject";
 
-export type ModalType = "CREATE_BOOKSHELF" | "TOKEN" | "ENTER_TOKEN" | null;
+export type ModalType =
+  | "CREATE_BOOKSHELF"
+  | "TOKEN"
+  | "ENTER_TOKEN"
+  | "ENTER_ID"
+  | null;
 
 export type ModalState =
   | { modalType: "CREATE_BOOKSHELF"; props: EmptyObject }
   | { modalType: "TOKEN"; props: { token: string } }
   | { modalType: "ENTER_TOKEN"; props: EmptyObject }
+  | { modalType: "ENTER_ID"; props: EmptyObject }
   | { modalType: null; props: EmptyObject };
 
 export interface ModalContextValue {

--- a/frontend/src/hooks/usePublicBookshelf.ts
+++ b/frontend/src/hooks/usePublicBookshelf.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { getBookshelfById, getBooksInBookshelfById } from "../api/bookshelves";
+import { type Book } from "../types/book";
+import { type Bookshelf } from "../types/bookshelf";
+
+export const usePublicBookshelf = (id: string) => {
+  const [bookshelf, setBookshelf] = useState<Bookshelf | null>(null);
+  const [books, setBooks] = useState<Book[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchBookshelf = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const fetchedBookshelf = await getBookshelfById(id);
+        if (!fetchedBookshelf) {
+          throw new Error("Bookshelf not found");
+        }
+        setBookshelf(fetchedBookshelf);
+        const fetchedBooks = await getBooksInBookshelfById(id);
+        setBooks(fetchedBooks || []);
+      } catch (err) {
+        setError((err as Error).message);
+      }
+      setLoading(false);
+    };
+
+    fetchBookshelf();
+  }, [id]);
+
+  return { bookshelf, books, loading, error };
+};

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,15 +1,25 @@
 {
   "common": {
-    "appName": "Bookshelf"
+    "appName": "Bookshelf",
+    "bookshelfNotFound": "Bookshelf not found",
+    "invalidBookshelfId": "Invalid Bookshelf ID",
+    "loading": "Loading..."
+  },
+  "bookshelfView": {
+    "books": "Books:",
+    "noBooks": "No books in this bookshelf. Start adding some!"
   },
   "button": {
+    "addBook": "Add Book",
     "cancel": "Cancel",
     "copyTokenToClipboard": "Copy token to clipboard",
     "create": "Create",
     "createBookshelf": "Create your own Bookshelf",
+    "deleteBookshelf": "Delete Bookshelf",
     "gotIt": "Got it!",
     "open": "Open",
-    "openMyBookshelf": "Open My Bookshelf"
+    "openMyBookshelf": "Open My Bookshelf",
+    "visitBookshelf": "Visit Bookshelf"
   },
   "home": {
     "welcomeDescription": "Add books, build shelves, and never lose track of what you’re reading.",
@@ -21,9 +31,11 @@
     "descriptionOfBookshelf": "Description of your Bookshelf (optional)",
     "descriptionPlaceholder": "What’s special about this bookshelf?",
     "enterEditToken": "Enter your bookshelf token",
+    "enterIdToVisit": "Enter the ID to visit a Bookshelf",
     "nameOfBookshelf": "Name of your Bookshelf",
     "namePlaceholder": "e.g. My Favorite Reads",
     "newBookshelfCreated": "Your Bookshelf Has Been Created",
+    "pasteIdHere": "Paste the ID here",
     "pasteTokenHere": "Paste your token here",
     "rememberToken": "Remember this token on this device",
     "saveTokenTitle": "Keep this token safe.",
@@ -34,7 +46,9 @@
     "anErrorOccurred": "An error occurred",
     "bookshelfLoadedSuccessfully": "Bookshelf loaded successfully",
     "failedToRefreshBookshelf": "Failed to refresh bookshelf",
+    "invalidBookshelfId": "Invalid bookshelf ID",
     "invalidTokenOrBookshelfNotFound": "Invalid token or bookshelf not found",
+    "noTokenFound": "No token found.",
     "tokenCopied": "Token copied to clipboard",
     "tokenCopyFailed": "Failed to copy token to clipboard",
     "tokenStored": "Your token has been stored on this device."

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,6 +10,7 @@ import { AppProviders } from "./contexts/AppProviders";
 import { Layout } from "./Layout";
 import { Home } from "./pages/Home";
 import { MyBookshelf } from "./pages/MyBookshelf";
+import { PublicBookshelf } from "./pages/PublicBookshelf";
 import "./index.css";
 
 const router = createBrowserRouter([
@@ -18,7 +19,7 @@ const router = createBrowserRouter([
     element: <Layout />,
     children: [
       { path: "/", element: <Home /> },
-      { path: "/bookshelves/:id", element: <p>Public Bookshelf</p> },
+      { path: "/bookshelves/:id", element: <PublicBookshelf /> },
       { path: "/my/bookshelf", element: <MyBookshelf /> },
       { path: "*", element: <Navigate to="/" replace /> },
     ],

--- a/frontend/src/pages/MyBookshelf.tsx
+++ b/frontend/src/pages/MyBookshelf.tsx
@@ -1,39 +1,25 @@
 import { type FC, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { BookshelfView } from "../components/commons/BookshelfVeiw";
+import { useLanguage } from "../hooks/useLanguage";
 import { useMyBookshelf } from "../hooks/useMyBookshelf";
 
 export const MyBookshelf: FC = () => {
   const { editToken, bookshelf, books } = useMyBookshelf();
+  const { t } = useLanguage();
   const navigate = useNavigate();
 
   useEffect(() => {
     if (!editToken) {
-      navigate("/");
+      toast.error(t("toast.noTokenFound"));
+      navigate("/", { replace: true });
     }
-  }, [editToken, navigate]);
+  }, [editToken, navigate, t]);
 
   if (!bookshelf) {
-    return <div>Loading...</div>;
+    return <div>{t("common.loading")}</div>;
   }
 
-  return (
-    <div>
-      <h1 className="text-2xl font-bold mb-4">{bookshelf.name}</h1>
-      <p className="mb-6">{bookshelf.description}</p>
-      {/* TODO: Update placeholder book rendering */}
-      <h2 className="text-xl font-semibold mb-2">Books:</h2>
-      {books.length === 0 ? (
-        <p>No books in your bookshelf. Start adding some!</p>
-      ) : (
-        <ul className="space-y-2">
-          {books.map((book) => (
-            <li key={book.id} className="border-b py-2">
-              <h3 className="font-semibold">{book.title}</h3>
-              <p className="text-sm text-gray-600">{book.author}</p>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  );
+  return <BookshelfView bookshelf={bookshelf} books={books} canEdit={true} />;
 };

--- a/frontend/src/pages/PublicBookshelf.tsx
+++ b/frontend/src/pages/PublicBookshelf.tsx
@@ -1,0 +1,26 @@
+import { type FC, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { BookshelfView } from "../components/commons/BookshelfVeiw";
+import { useLanguage } from "../hooks/useLanguage";
+import { usePublicBookshelf } from "../hooks/usePublicBookshelf";
+
+export const PublicBookshelf: FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const { bookshelf, books, loading, error } = usePublicBookshelf(id!);
+  const { t } = useLanguage();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (error) {
+      toast.error(error);
+      navigate("/", { replace: true });
+    }
+  }, [error, navigate]);
+
+  if (!id) return <div>{t("common.invalidBookshelfId")}</div>;
+  if (loading) return <div>{t("common.loading")}</div>;
+  if (!bookshelf) return <div>{t("common.bookshelfNotFound")}</div>;
+
+  return <BookshelfView bookshelf={bookshelf} books={books} canEdit={false} />;
+};


### PR DESCRIPTION
- Added PublicBookshelf page component for visiting any bookshelf
- Added unified BookshelfView component shared across personal and public views
  - PublicBookshelf: view-only
  - MyBookshelf: view, add, edit, and delete books
- Split routes into /my/bookshelf and /bookshelves/:id
- Added flow to visit any bookshelf:
  - via modal prompt accepting a bookshelf ID
  - implemented new API functions getBookshelfById and getBooksInBookshelfById