### PR TITLE
Add conditional frontend and backend workflows using paths-filter

### DIFF
--- a/.github/workflows/verify-backend-pr.yml
+++ b/.github/workflows/verify-backend-pr.yml
@@ -4,12 +4,30 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "backend/**"
 
 jobs:
+  detect-changes:
+    name: Check Paths For Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      backend_changed: ${{ steps.changes.outputs.backend }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Detect file changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+
   lint:
     name: Run Ktlint
+    needs: detect-changes
+    if: needs.detect-changes.outputs.backend_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -34,7 +52,8 @@ jobs:
 
   assemble:
     name: Assemble Project
-    needs: lint
+    needs: [detect-changes, lint]
+    if: needs.detect-changes.outputs.backend_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/verify-frontend-pr.yml
+++ b/.github/workflows/verify-frontend-pr.yml
@@ -4,12 +4,30 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "frontend/**"
 
 jobs:
+  detect-changes:
+    name: Check Paths For Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      frontend_changed: ${{ steps.changes.outputs.frontend }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Detect file changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            frontend:
+              - 'frontend/**'
+
   license-check:
     name: License Compliance Check
+    needs: detect-changes
+    if: needs.detect-changes.outputs.frontend_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -43,7 +61,8 @@ jobs:
 
   lint:
     name: Run ESLint
-    needs: license-check
+    needs: [detect-changes, license-check]
+    if: needs.detect-changes.outputs.frontend_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -68,7 +87,8 @@ jobs:
 
   build:
     name: Build Project
-    needs: lint
+    needs: [detect-changes, lint]
+    if: needs.detect-changes.outputs.frontend_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
 


### PR DESCRIPTION
- Integrated dorny/paths-filter to detect modified folders per PR
- Made backend workflow run Ktlint and assemble only when backend/** changes
- Made frontend workflow run license check, ESLint, and build only when frontend/** changes
- Ensured both workflows always report status for branch protection