### PR TITLE
Update Docker development setup to work with WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Visitors can browse public bookshelves, while owners can create, edit, and manag
 ## Tech Stack
 
 **Frontend:** React + TypeScript + TailwindCSS + Vite  
-**Backend:** Kotlin (Sprint Boot) + SQLite + Gradle  
+**Backend:** Kotlin + Spring Boot + SQLite + Gradle  
 **Infrastructure:** Docker + GitHub Actions
 
 ## Development Environment
@@ -31,7 +31,7 @@ The following tools and versions are used during local development of the Booksh
 
 - **Java 21 (LTS)** – developed with Eclipse Temurin 21.0.8
 - **Gradle** – use included Gradle Wrapper (`./gradlew`), no need to install globally
-- **SQLite** – database used by backend, file-based (`bookshelf.db` auto-created)
+- **SQLite** – database used by backend, file-based (`bookshelf.db`)
 
 ### Frontend
 
@@ -63,9 +63,24 @@ These settings ensure:
 > <br/>
 > This means backend hot reload can still work in VS Code as long as IntelliJ’s background compiler is active.
 
+### Local SQLite Database
+
+The backend stores data in a local SQLite database file named `bookshelf.db`.
+
+Before running the application (especially inside Docker for the first time),
+make sure that the file exists in the `backend` directory:
+
+```bash
+cd backend
+touch bookshelf.db
+```
+
+This prevents Docker from accidentally creating a folder with the same name during volume mounts.
+The file is local and ignored by Git, so your development data remains on your machine.
+
 ### Run the Development Environment
 
-Use the development‑specific Compose file:
+Use the development‑specific Compose file located in the project’s root directory:
 
 ```bash
 docker compose -f docker-compose.dev.yml up --build

--- a/README.md
+++ b/README.md
@@ -41,28 +41,6 @@ The following tools and versions are used during local development of the Booksh
 
 This project includes a full Docker‑based setup for local development with hot reload on both the frontend and backend.
 
-### Backend Hot Reload Prerequisites (IntelliJ IDEA)
-
-> This section applies to **backend development in IntelliJ IDEA**.
-> <br/>
-> If you only work on the frontend, you can skip this part.
-
-To enable backend hot reload, configure IntelliJ IDEA to automatically rebuild the project whenever you save changes.
-
-1. Open **File** → **Settings** → **Build, Execution, Deployment** → **Compiler**
-2. Enable **Build project automatically**
-
-These settings ensure:
-
-- IntelliJ recompiles classes on every save,
-- Updated `.class` files sync instantly into the Docker container,
-- **Spring Boot DevTools** detects the change and restarts the backend automatically.
-
-> **Note:** <br/>
-> If IntelliJ IDEA remains open, its auto‑build process continuously recompiles classes even if you’re editing the code in another editor (like **VS Code**).
-> <br/>
-> This means backend hot reload can still work in VS Code as long as IntelliJ’s background compiler is active.
-
 ### Local SQLite Database
 
 The backend stores data in a local SQLite database file named `bookshelf.db`.
@@ -77,6 +55,43 @@ touch bookshelf.db
 
 This prevents Docker from accidentally creating a folder with the same name during volume mounts.
 The file is local and ignored by Git, so your development data remains on your machine.
+
+### Frontend Hot Reload
+
+The frontend runs a Vite development server inside its Docker container.
+
+When you edit files under `frontend/src/`, the changes are detected automatically and the browser reloads almost instantly.  
+No manual rebuild or container restart is required.
+
+This behavior works the same across all platforms (Windows, macOS, WSL, Linux).
+
+### Backend Hot Reload (Spring Boot + Gradle)
+
+Bookshelf’s backend supports live rebuild and auto‑restart using:
+
+- `./gradlew classes --continuous` (watches for Kotlin source changes)
+- **Spring Boot DevTools** (watches compiled `.class` file updates)
+
+Depending on your operating system, hot reload behaves slightly differently:
+
+#### On Linux / WSL2
+
+You can get full backend hot reload **without** any IDE configuration — just run Docker Compose in the [Run the Development Environment](#run-the-development-environment) section.
+
+File changes under `backend/src/` trigger Gradle’s continuous build inside the container, and the running Spring Boot app restarts automatically.
+
+#### On Windows with IntelliJ IDEA
+
+On Windows, file‑watch events aren’t always detected instantly inside Docker due to filesystem translation between Windows → WSL → Docker.
+
+To ensure backend hot reload works reliably, configure the following settings in IntelliJ IDEA:
+
+1. Open **File** → **Settings** → **Build, Execution, Deployment** → **Compiler**
+2. Enable **Build project automatically**
+
+This approach ensures consistent development experience across platforms by offloading compilation to IntelliJ when Docker’s Linux file watcher cannot fully detect edits made on Windows file systems.
+
+**Tip:** Even if you edit code in VS Code or another editor, IntelliJ’s compiler can still handle background compilation — just keep IntelliJ open.
 
 ### Run the Development Environment
 

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -2,11 +2,16 @@ FROM eclipse-temurin:21-jdk-alpine
 
 WORKDIR /workspace/backend
 
-COPY . .
-
-RUN chmod +x ./gradlew
 RUN apk add --no-cache curl
 
-EXPOSE 8080
+COPY gradlew .
+COPY gradle/wrapper ./gradle/wrapper
+COPY build.gradle.kts settings.gradle.kts ./
 
-CMD ["./gradlew", "bootRun", "--no-daemon"]
+RUN chmod +x ./gradlew
+RUN ./gradlew dependencies --no-daemon
+
+COPY . .
+
+EXPOSE 8080
+CMD ["sh", "-c", "chmod +x ./gradlew && ./gradlew bootRun --no-daemon"]

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -9,9 +9,9 @@ COPY gradle/wrapper ./gradle/wrapper
 COPY build.gradle.kts settings.gradle.kts ./
 
 RUN chmod +x ./gradlew
-RUN ./gradlew dependencies --no-daemon
+RUN ./gradlew clean build -x test --no-daemon || echo "Skipping failed build (intended for dependency caching)"
 
 COPY . .
 
 EXPOSE 8080
-CMD ["sh", "-c", "chmod +x ./gradlew && ./gradlew bootRun --no-daemon"]
+CMD ["sh", "-c", "chmod +x ./gradlew && ./gradlew classes --continuous --no-daemon & ./gradlew bootRun --no-daemon"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,6 +6,7 @@ services:
     container_name: bookshelf-backend
     ports:
       - "8080:8080"
+      - "35729:35729"
     volumes:
       - ./backend:/workspace/backend
       - ./backend/bookshelf.db:/workspace/backend/bookshelf.db
@@ -15,8 +16,11 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: dev
       SPRING_DEVTOOLS_RESTART_ENABLED: "true"
+      SPRING_DEVTOOLS_LIVERELOAD_ENABLED: "true"
+      SPRING_DEVTOOLS_RESTART_ADDITIONAL_PATHS: /workspace/backend/build/classes,/workspace/backend/src/main/kotlin
     tty: true
     stdin_open: true
+    restart: unless-stopped
     healthcheck:
       test:
         - CMD-SHELL

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,7 +26,7 @@ services:
           http://127.0.0.1:8080/api/v1/health | grep -q 200
       interval: 5s
       timeout: 3s
-      retries: 10
+      retries: 60
       start_period: 30s
 
   frontend:


### PR DESCRIPTION
- Modified backend Dockerfile to:
  - Cache Gradle dependencies and skip tests during dependency warmup.
  - Enable continuous class rebuilding (`gradlew classes --continuous`) for live reload.
- Updated docker-compose.dev.yml:
  - Exposed LiveReload port (35729) and added Spring DevTools environment variables.
  - Added restart policy and tuned healthcheck settings.
- Revised README:
  - Added clear instructions for WSL2 and Windows (IntelliJ IDEA) development.
  - Clarified frontend and backend hot reload behavior.
  - Improved formatting and overall structure.

These changes make the Dockerized workflow consistent across Linux, WSL2, and Windows
while maintaining automatic rebuild and reload for both frontend and backend services.