### PR TITLE
Add full end-to-end integration test for Bookshelf API

### DIFF
--- a/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/controller/BookshelfController.kt
+++ b/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/controller/BookshelfController.kt
@@ -297,7 +297,7 @@ class BookshelfController(
                 val deletedBookCount = bookshelfService.deleteBookshelf(bookshelf.value.publicId).getOrNull()!!
                 val payload =
                     DeleteBookshelfResult(
-                        deletedBookshelfId = bookshelf.value.id,
+                        deletedBookshelfPublicId = bookshelf.value.publicId,
                         deletedBooksCount = deletedBookCount,
                     )
                 ResponseEntity.ok(ApiResponse(data = payload))

--- a/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/controller/dto/BookshelfDtos.kt
+++ b/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/controller/dto/BookshelfDtos.kt
@@ -52,6 +52,6 @@ data class UpdateBookshelfDto(
  * Returned when deleting an entire bookshelf (for informational purposes).
  */
 data class DeleteBookshelfResult(
-    val deletedBookshelfId: Long,
+    val deletedBookshelfPublicId: String,
     val deletedBooksCount: Long,
 )

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -4,7 +4,7 @@ spring:
     driver-class-name: org.sqlite.JDBC
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: create-drop
     properties:
       hibernate:
         dialect: org.hibernate.community.dialect.SQLiteDialect

--- a/backend/src/test/kotlin/io/github/tyostokarry/bookshelf/controller/BookshelfControllerTest.kt
+++ b/backend/src/test/kotlin/io/github/tyostokarry/bookshelf/controller/BookshelfControllerTest.kt
@@ -835,7 +835,7 @@ class BookshelfControllerTest(
                     Book(bookshelfId = 10, id = 10, title = "Test title 1", author = "Test author 1"),
                     Book(bookshelfId = 10, id = 11, title = "Test title 2", author = "Test author 2"),
                 )
-            val deleted = DeleteBookshelfResult(bookshelf.id, books.size.toLong())
+            val deleted = DeleteBookshelfResult(bookshelf.publicId, books.size.toLong())
             given(bookshelfService.getBookshelfByPublicId(bookshelf.publicId)).willReturn(Either.Right(bookshelf))
             given(bookshelfService.deleteBookshelf(bookshelf.publicId)).willReturn(Either.Right(deleted.deletedBooksCount))
 

--- a/backend/src/test/kotlin/io/github/tyostokarry/bookshelf/integration/BookshelfIntegrationTest.kt
+++ b/backend/src/test/kotlin/io/github/tyostokarry/bookshelf/integration/BookshelfIntegrationTest.kt
@@ -1,0 +1,223 @@
+package io.github.tyostokarry.bookshelf.integration
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.github.tyostokarry.bookshelf.controller.advice.ApiResponse
+import io.github.tyostokarry.bookshelf.controller.dto.BookDto
+import io.github.tyostokarry.bookshelf.controller.dto.BookshelfDto
+import io.github.tyostokarry.bookshelf.controller.dto.BookshelfWithTokenDto
+import io.github.tyostokarry.bookshelf.controller.dto.CreateBookDto
+import io.github.tyostokarry.bookshelf.controller.dto.CreateBookshelfDto
+import io.github.tyostokarry.bookshelf.controller.dto.DeleteBookshelfResult
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import java.time.temporal.ChronoUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class BookshelfIntegrationTest(
+    @Autowired val mockMvc: MockMvc,
+    @Autowired val objectMapper: ObjectMapper,
+) {
+    private val apiKey = "test-key"
+
+    @Test
+    fun `should create and then retrieve a bookshelf`() {
+        // Create a new bookshelf
+        val createBookshelfPayload = CreateBookshelfDto(name = "New bookshelf", description = "Test bookshelf")
+
+        val createBookshelfResponseBody =
+            mockMvc
+                .post("/api/v1/bookshelves") {
+                    header("X-API-KEY", apiKey)
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(createBookshelfPayload)
+                }.andExpect { status { isOk() } }
+                .andReturn()
+                .response
+                .contentAsString
+
+        val createBookshelfTypeRef = object : TypeReference<ApiResponse<BookshelfWithTokenDto>>() {}
+        val createBookshelfResponse: ApiResponse<BookshelfWithTokenDto> =
+            objectMapper.readValue(
+                createBookshelfResponseBody,
+                createBookshelfTypeRef,
+            )
+
+        assertNotNull(createBookshelfResponse.data, "Create response data should not be null")
+        val createBookshelfResponseData = createBookshelfResponse.data!!
+        assertEquals(
+            createBookshelfPayload.name,
+            createBookshelfResponseData.name,
+            "Create response bookshelf name should match create payload",
+        )
+        assertEquals(
+            createBookshelfPayload.description,
+            createBookshelfResponseData.description,
+            "Create response bookshelf description should match create payload",
+        )
+        assertNotNull(createBookshelfResponseData.publicId, "Create response bookshelf publicId should not be null")
+        assertNotNull(createBookshelfResponseData.editToken, "Create response bookshelf editToken should not be null")
+        assertNull(createBookshelfResponse.error, "Create response error should be null for successful response")
+
+        // Get bookshelf by publicId
+        val getBookshelfResponseBody =
+            mockMvc
+                .get("/api/v1/bookshelves/${createBookshelfResponseData.publicId}") {
+                    header("X-API-KEY", apiKey)
+                }.andExpect { status { isOk() } }
+                .andReturn()
+                .response
+                .contentAsString
+
+        val getBookshelfTypeRef = object : TypeReference<ApiResponse<BookshelfDto>>() {}
+        val getBookshelfResponse: ApiResponse<BookshelfDto> = objectMapper.readValue(getBookshelfResponseBody, getBookshelfTypeRef)
+
+        assertNotNull(getBookshelfResponse.data, "Get response data should not be null")
+        val getBookshelfResponseData = getBookshelfResponse.data!!
+        assertEquals(
+            createBookshelfResponseData.name,
+            getBookshelfResponseData.name,
+            "Fetched bookshelf name should match created bookshelf",
+        )
+        assertEquals(
+            createBookshelfResponseData.description,
+            getBookshelfResponseData.description,
+            "Fetched bookshelf description should match created bookshelf",
+        )
+        assertEquals(
+            createBookshelfResponseData.publicId,
+            getBookshelfResponseData.publicId,
+            "Fetched bookshelf publicId should be the same as the created one",
+        )
+        assertEquals(
+            createBookshelfResponseData.createdAt.truncatedTo(ChronoUnit.MILLIS),
+            getBookshelfResponseData.createdAt.truncatedTo(ChronoUnit.MILLIS),
+            "CreatedAt timestamp should match up to millisecond precision",
+        )
+        assertEquals(
+            createBookshelfResponseData.updatedAt.truncatedTo(ChronoUnit.MILLIS),
+            getBookshelfResponseData.updatedAt.truncatedTo(ChronoUnit.MILLIS),
+            "UpdatedAt timestamp should match up to millisecond precision",
+        )
+        assertNull(getBookshelfResponse.error, "Get response error should be null for successful response")
+
+        // Add 2 books to bookshelf
+        val createBookPayloadOne = CreateBookDto(title = "New book 1", author = "Test author 1")
+        val createBookPayloadTwo = CreateBookDto(title = "New book 2", author = "Test author 2")
+
+        val createBookOneResponseBody =
+            mockMvc
+                .post("/api/v1/bookshelves/${getBookshelfResponseData.publicId}/books") {
+                    header("X-API-KEY", apiKey)
+                    header("X-BOOKSHELF-TOKEN", createBookshelfResponseData.editToken)
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(createBookPayloadOne)
+                }.andExpect { status { isOk() } }
+                .andReturn()
+                .response
+                .contentAsString
+
+        val createBookTwoResponseBody =
+            mockMvc
+                .post("/api/v1/bookshelves/${getBookshelfResponseData.publicId}/books") {
+                    header("X-API-KEY", apiKey)
+                    header("X-BOOKSHELF-TOKEN", createBookshelfResponseData.editToken)
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(createBookPayloadTwo)
+                }.andExpect { status { isOk() } }
+                .andReturn()
+                .response
+                .contentAsString
+
+        val bookTypeRef = object : TypeReference<ApiResponse<BookDto>>() {}
+        val createBookOneResponse: ApiResponse<BookDto> = objectMapper.readValue(createBookOneResponseBody, bookTypeRef)
+        val createBookTwoResponse: ApiResponse<BookDto> = objectMapper.readValue(createBookTwoResponseBody, bookTypeRef)
+
+        assertNotNull(createBookOneResponse.data, "First created book response data should not be null")
+        assertNotNull(createBookTwoResponse.data, "Second created book response data should not be null")
+        val createdBookOne = createBookOneResponse.data!!
+        val createdBookTwo = createBookTwoResponse.data!!
+        assertEquals(
+            createBookPayloadOne.title,
+            createdBookOne.title,
+            "First created book should have matching title",
+        )
+        assertEquals(
+            createBookPayloadTwo.title,
+            createdBookTwo.title,
+            "Second created book should have matching title",
+        )
+        assertNull(createBookOneResponse.error, "Get first book response error should be null for successful response")
+        assertNull(createBookTwoResponse.error, "Get second book response error should be null for successful response")
+
+        // Retrieve all books in the bookshelf and verify both are returned
+        val getBooksResponseBody =
+            mockMvc
+                .get("/api/v1/bookshelves/${getBookshelfResponseData.publicId}/books") {
+                    header("X-API-KEY", apiKey)
+                }.andExpect { status { isOk() } }
+                .andReturn()
+                .response
+                .contentAsString
+
+        val bookListTypeRef = object : TypeReference<ApiResponse<List<BookDto>>>() {}
+        val getBooksResponse: ApiResponse<List<BookDto>> = objectMapper.readValue(getBooksResponseBody, bookListTypeRef)
+
+        assertNotNull(getBooksResponse.data, "Get books response data should not be null")
+        val getBooksResponseData = getBooksResponse.data!!
+        assertEquals(2, getBooksResponseData.size, "There should be exactly 2 books in the bookshelf after creation")
+        val titles = getBooksResponseData.map { it.title }.toSet()
+        assert(titles.containsAll(listOf("New book 1", "New book 2"))) {
+            "Expected both book titles ('New book 1', 'New book 2') to be present in retrieved list"
+        }
+        assertNull(getBooksResponse.error, "Get books response error should be null for successful response")
+
+        // Delete bookshelf
+        val deleteBookshelfResponseBody =
+            mockMvc
+                .delete("/api/v1/bookshelves/${getBookshelfResponseData.publicId}") {
+                    header("X-API-KEY", apiKey)
+                    header("X-BOOKSHELF-TOKEN", createBookshelfResponseData.editToken)
+                }.andExpect { status { isOk() } }
+                .andReturn()
+                .response
+                .contentAsString
+
+        val deleteTypeRef = object : TypeReference<ApiResponse<DeleteBookshelfResult>>() {}
+        val deleteBookshelfResponse: ApiResponse<DeleteBookshelfResult> = objectMapper.readValue(deleteBookshelfResponseBody, deleteTypeRef)
+
+        assertNotNull(deleteBookshelfResponse.data, "Delete bookshelf response data should not be null")
+        val deleteBookshelfResponseData = deleteBookshelfResponse.data!!
+        assertEquals(
+            getBookshelfResponseData.publicId,
+            deleteBookshelfResponseData.deletedBookshelfPublicId,
+            "Deleted bookshelf public id should be match the original created bookshelf",
+        )
+        assertEquals(
+            getBooksResponseData.size.toLong(),
+            deleteBookshelfResponseData.deletedBooksCount,
+            "Deleted book count should match the size of ",
+        )
+        assertNull(deleteBookshelfResponse.error, "Number of deleted books should equal the number of books that existed in the bookshelf")
+    }
+
+    @Test
+    fun `should reject requests with missing or invalid api key`() {
+        mockMvc
+            .get("/api/v1/bookshelves")
+            .andExpect { status { isUnauthorized() } }
+    }
+}


### PR DESCRIPTION
- Implemented `BookshelfIntegrationTest` using MockMvc and real SQLite DB
- Tests complete flow: create bookshelf, get bookshelf, add books, retrieve books, delete bookshelf
- Verifies API key and edit token security behavior
- Updated `application-test.yml` to use `ddl-auto: create-drop` for schema creation
- Adjusted DeleteBookshelfResult and controller to include publicId in response