### PR TITLE
Add Argon2 support and composite editToken format for secure bookshel…

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -32,6 +32,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("com.aventrix.jnanoid:jnanoid:2.0.0")
+    implementation("org.springframework.security:spring-security-crypto")
+    implementation("org.bouncycastle:bcprov-jdk18on:1.82")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/controller/BookshelfController.kt
+++ b/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/controller/BookshelfController.kt
@@ -118,8 +118,9 @@ class BookshelfController(
     fun createBookshelf(
         @Valid @RequestBody dto: CreateBookshelfDto,
     ): ResponseEntity<ApiResponse<BookshelfWithTokenDto>> {
-        val newBookshelf = bookshelfService.saveBookshelf(dto.toEntity())
-        return ResponseEntity.ok(ApiResponse(data = newBookshelf.toBookshelfWithTokenDto()))
+        val (rawEditToken, bookshelf) = bookshelfService.createBookshelf(dto.name, dto.description)
+        val createBookshelfResponse = bookshelf.toBookshelfWithTokenDto(rawEditToken)
+        return ResponseEntity.ok(ApiResponse(data = createBookshelfResponse))
     }
 
     @PostMapping("/{publicId}/books")
@@ -130,7 +131,7 @@ class BookshelfController(
     ): ResponseEntity<ApiResponse<BookDto>> {
         return when (val bookshelf = bookshelfService.getBookshelfByPublicId(publicId)) {
             is Either.Right -> {
-                if (token == null || bookshelf.value.editToken != token) {
+                if (token == null || !bookshelfService.verifyToken(bookshelf.value, token)) {
                     return ResponseEntity
                         .status(403)
                         .body(
@@ -170,7 +171,7 @@ class BookshelfController(
     ): ResponseEntity<ApiResponse<BookshelfDto>> {
         return when (val existingBookshelf = bookshelfService.getBookshelfByPublicId(publicId)) {
             is Either.Right -> {
-                if (token == null || existingBookshelf.value.editToken != token) {
+                if (token == null || !bookshelfService.verifyToken(existingBookshelf.value, token)) {
                     return ResponseEntity
                         .status(403)
                         .body(
@@ -212,7 +213,7 @@ class BookshelfController(
     ): ResponseEntity<ApiResponse<BookDto>> {
         return when (val bookshelf = bookshelfService.getBookshelfByPublicId(publicId)) {
             is Either.Right -> {
-                if (token == null || bookshelf.value.editToken != token) {
+                if (token == null || !bookshelfService.verifyToken(bookshelf.value, token)) {
                     return ResponseEntity
                         .status(403)
                         .body(
@@ -280,7 +281,7 @@ class BookshelfController(
     ): ResponseEntity<ApiResponse<DeleteBookshelfResult>> {
         return when (val bookshelf = bookshelfService.getBookshelfByPublicId(publicId)) {
             is Either.Right -> {
-                if (token == null || bookshelf.value.editToken != token) {
+                if (token == null || !bookshelfService.verifyToken(bookshelf.value, token)) {
                     return ResponseEntity
                         .status(403)
                         .body(
@@ -325,7 +326,7 @@ class BookshelfController(
     ): ResponseEntity<ApiResponse<Long>> {
         return when (val bookshelf = bookshelfService.getBookshelfByPublicId(publicId)) {
             is Either.Right -> {
-                if (token == null || bookshelf.value.editToken != token) {
+                if (token == null || !bookshelfService.verifyToken(bookshelf.value, token)) {
                     return ResponseEntity
                         .status(
                             403,

--- a/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/controller/dto/BookshelfMapper.kt
+++ b/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/controller/dto/BookshelfMapper.kt
@@ -11,20 +11,14 @@ fun Bookshelf.toBookshelfDto() =
         updatedAt = this.updatedAt,
     )
 
-fun Bookshelf.toBookshelfWithTokenDto() =
+fun Bookshelf.toBookshelfWithTokenDto(rawEditToken: String) =
     BookshelfWithTokenDto(
         publicId = this.publicId,
         name = this.name,
         description = this.description,
         createdAt = this.createdAt,
         updatedAt = this.updatedAt,
-        editToken = this.editToken,
-    )
-
-fun CreateBookshelfDto.toEntity() =
-    Bookshelf(
-        name = name,
-        description = description,
+        editToken = rawEditToken,
     )
 
 fun UpdateBookshelfDto.applyTo(bookshelf: Bookshelf): Bookshelf {

--- a/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/entity/Bookshelf.kt
+++ b/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/entity/Bookshelf.kt
@@ -23,10 +23,14 @@ data class Bookshelf(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
     /**
-     * Auto-generated publicly facing identifier used for bookshelf visits
+     * Publicly visible, random identifier that uniquely references this bookshelf.
+     *
+     * Generated once in the service layer (using NanoID) during creation,
+     * and remains stable for the lifetime of the bookshelf. Used both for
+     * sharing and as the public prefix in the owner’s edit token.
      */
     @Column(nullable = false, unique = true, updatable = false)
-    val publicId: String = NanoIdUtils.randomNanoId(),
+    val publicId: String,
     /**
      * Name of the bookshelf (e.g. "My Shelf", "Summer Reads").
      */
@@ -49,13 +53,12 @@ data class Bookshelf(
     @Column(nullable = false)
     var updatedAt: LocalDateTime = LocalDateTime.now(),
     /**
-     * Secret owner token (do NOT expose in normal responses)
+     * Hashed edit token for bookshelf ownership verification.
+     * The raw token is generated once, returned to the client, and never stored.
+     * Only this Argon2 id hash is saved and used for future token validation.
      */
     @Column(nullable = false)
-    var editToken: String =
-        java.util.UUID
-            .randomUUID()
-            .toString(),
+    var editTokenHash: String,
 ) {
     @PreUpdate
     fun onUpdate() {

--- a/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/entity/Bookshelf.kt
+++ b/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/entity/Bookshelf.kt
@@ -1,6 +1,5 @@
 package io.github.tyostokarry.bookshelf.entity
 
-import com.aventrix.jnanoid.jnanoid.NanoIdUtils
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue

--- a/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/repository/BookshelfRepository.kt
+++ b/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/repository/BookshelfRepository.kt
@@ -14,12 +14,4 @@ interface BookshelfRepository : JpaRepository<Bookshelf, Long> {
      * @return bookshelf that is linked with the publicId
      */
     fun findByPublicId(publicId: String): Bookshelf?
-
-    /**
-     * Finds bookshelf that is linked to given edit token.
-     *
-     * @param editToken of the bookshelf
-     * @return bookshelf that is linked with the edit token
-     */
-    fun findByEditToken(editToken: String): Bookshelf?
 }

--- a/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/security/TokenHasher.kt
+++ b/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/security/TokenHasher.kt
@@ -1,0 +1,16 @@
+package io.github.tyostokarry.bookshelf.security
+
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder
+import org.springframework.stereotype.Component
+
+@Component
+class TokenHasher {
+    private val delegate = Argon2PasswordEncoder(16, 32, 1, 65536, 3)
+
+    fun hash(raw: String): String = delegate.encode(raw)
+
+    fun match(
+        raw: String,
+        hashed: String,
+    ): Boolean = delegate.matches(raw, hashed)
+}

--- a/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/service/BookshelfService.kt
+++ b/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/service/BookshelfService.kt
@@ -3,9 +3,12 @@ package io.github.tyostokarry.bookshelf.service
 import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
+import com.aventrix.jnanoid.jnanoid.NanoIdUtils
 import io.github.tyostokarry.bookshelf.entity.Bookshelf
 import io.github.tyostokarry.bookshelf.error.BookshelfError
 import io.github.tyostokarry.bookshelf.repository.BookshelfRepository
+import io.github.tyostokarry.bookshelf.security.TokenHasher
+import org.hibernate.validator.constraints.UUID
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
@@ -13,6 +16,7 @@ import org.springframework.stereotype.Service
 class BookshelfService(
     private val bookService: BookService,
     private val bookshelfRepository: BookshelfRepository,
+    private val tokenHasher: TokenHasher,
 ) {
     fun getAllBookshelves(): List<Bookshelf> = bookshelfRepository.findAll()
 
@@ -22,8 +26,45 @@ class BookshelfService(
     fun getBookshelfByPublicId(publicId: String): Either<BookshelfError, Bookshelf> =
         bookshelfRepository.findByPublicId(publicId)?.right() ?: BookshelfError.NotFoundByPublicId(publicId).left()
 
-    fun getBookshelfByToken(editToken: String): Either<BookshelfError, Bookshelf> =
-        bookshelfRepository.findByEditToken(editToken)?.right() ?: BookshelfError.NotFoundByToken(editToken).left()
+    fun getBookshelfByToken(editToken: String): Either<BookshelfError, Bookshelf> {
+        val (publicId, _) =
+            editToken.split(".", limit = 2).let {
+                it.getOrNull(0) to it.getOrNull(1)
+            }
+
+        if (publicId == null) {
+            return BookshelfError.NotFoundByToken(editToken).left()
+        }
+
+        val bookshelf =
+            bookshelfRepository.findByPublicId(publicId)
+                ?: return BookshelfError.NotFoundByPublicId(publicId).left()
+
+        return if (tokenHasher.match(editToken, bookshelf.editTokenHash)) {
+            bookshelf.right()
+        } else {
+            BookshelfError.NotFoundByToken(editToken).left()
+        }
+    }
+
+    fun createBookshelf(
+        dtoName: String,
+        dtoDescription: String?,
+    ): Pair<String, Bookshelf> {
+        val publicId = NanoIdUtils.randomNanoId()
+        val rawEditToken = "$publicId.${java.util.UUID.randomUUID()}"
+        val hashedEditToken = tokenHasher.hash(rawEditToken)
+        val savedBookshelf =
+            bookshelfRepository.save(
+                Bookshelf(name = dtoName, description = dtoDescription, publicId = publicId, editTokenHash = hashedEditToken),
+            )
+        return rawEditToken to savedBookshelf
+    }
+
+    fun verifyToken(
+        bookshelf: Bookshelf,
+        providedToken: String,
+    ): Boolean = tokenHasher.match(providedToken, bookshelf.editTokenHash)
 
     fun saveBookshelf(bookshelf: Bookshelf): Bookshelf = bookshelfRepository.save(bookshelf)
 

--- a/backend/src/test/kotlin/io/github/tyostokarry/bookshelf/controller/BookControllerTest.kt
+++ b/backend/src/test/kotlin/io/github/tyostokarry/bookshelf/controller/BookControllerTest.kt
@@ -44,7 +44,7 @@ class BookControllerTest(
     inner class GetAllBooks {
         @Test
         fun `Get all books returns list of BookDto`() {
-            val bookshelf = Bookshelf(id = 1, publicId = "publicId", name = "Test Name")
+            val bookshelf = Bookshelf(id = 1, publicId = "publicId", name = "Test Name", editTokenHash = "editTokenHash")
             val books =
                 listOf(
                     Book(id = 1, bookshelfId = 1, title = "Test Book 1", author = "Author One"),
@@ -80,7 +80,7 @@ class BookControllerTest(
     inner class GetBookById {
         @Test
         fun `Get book returns BookDto when book is found`() {
-            val bookshelf = Bookshelf(id = 1, publicId = "publicId", name = "Test Name")
+            val bookshelf = Bookshelf(id = 1, publicId = "publicId", name = "Test Name", editTokenHash = "editTokenHash")
             val book = Book(id = 10, bookshelfId = 5, title = "Test Book 1", author = "Author One")
             given(bookService.getBookById(book.id)).willReturn(Either.Right(book))
             given(bookshelfService.getBookshelfById(any())).willReturn(Either.Right(bookshelf))

--- a/backend/src/test/kotlin/io/github/tyostokarry/bookshelf/service/BookshelfServiceTest.kt
+++ b/backend/src/test/kotlin/io/github/tyostokarry/bookshelf/service/BookshelfServiceTest.kt
@@ -3,19 +3,24 @@ package io.github.tyostokarry.bookshelf.service
 import io.github.tyostokarry.bookshelf.entity.Bookshelf
 import io.github.tyostokarry.bookshelf.error.BookshelfError
 import io.github.tyostokarry.bookshelf.repository.BookshelfRepository
+import io.github.tyostokarry.bookshelf.security.TokenHasher
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
 import java.util.Optional
+import java.util.UUID
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class BookshelfServiceTest {
     private val bookService: BookService = mock()
     private val bookshelfRepository: BookshelfRepository = mock()
-    private val bookshelfService = BookshelfService(bookService, bookshelfRepository)
+    private val tokenHasher = mock<TokenHasher>()
+    private val bookshelfService = BookshelfService(bookService, bookshelfRepository, tokenHasher)
 
     @Nested
     inner class GetAllBookshelves {
@@ -23,8 +28,14 @@ class BookshelfServiceTest {
         fun `getAllBookshelves returns list of shelves`() {
             val bookshelves =
                 listOf(
-                    Bookshelf(id = 1L, name = "My Shelf", description = "desc 1"),
-                    Bookshelf(id = 2L, name = "Another Shelf", description = "desc 2"),
+                    Bookshelf(id = 1L, name = "My Shelf", description = "desc 1", publicId = "publicID", editTokenHash = "editTokenHash"),
+                    Bookshelf(
+                        id = 2L,
+                        name = "Another Shelf",
+                        description = "desc 2",
+                        publicId = "publicID",
+                        editTokenHash = "editTokenHash",
+                    ),
                 )
             given(bookshelfRepository.findAll()).willReturn(bookshelves)
 
@@ -39,7 +50,8 @@ class BookshelfServiceTest {
     inner class GetBookshelfById {
         @Test
         fun `getBookshelfById returns Right when found`() {
-            val bookshelf = Bookshelf(id = 1L, publicId = "publicID", name = "Test bookshelf")
+            val bookshelf =
+                Bookshelf(id = 1L, publicId = "publicID", name = "Test bookshelf", editTokenHash = "editTokenHash")
             given(bookshelfRepository.findById(bookshelf.id)).willReturn(Optional.of(bookshelf))
 
             val result = bookshelfService.getBookshelfById(bookshelf.id)
@@ -63,7 +75,7 @@ class BookshelfServiceTest {
     inner class GetBookshelfByPublicId {
         @Test
         fun `getBookshelfByPublicId returns Right when found`() {
-            val bookshelf = Bookshelf(id = 1L, publicId = "publicID", name = "Test bookshelf")
+            val bookshelf = Bookshelf(id = 1L, publicId = "publicID", name = "Test bookshelf", editTokenHash = "editTokenHash")
             given(bookshelfRepository.findByPublicId(bookshelf.publicId)).willReturn(bookshelf)
 
             val result = bookshelfService.getBookshelfByPublicId(bookshelf.publicId)
@@ -91,27 +103,102 @@ class BookshelfServiceTest {
     inner class GetBookshelfByToken {
         @Test
         fun `getBookshelfByToken returns Right when found`() {
-            val bookshelf = Bookshelf(id = 1L, name = "Test bookshelf", editToken = "testEditToken123")
-            given(bookshelfRepository.findByEditToken(bookshelf.editToken)).willReturn(bookshelf)
+            val publicId = "publicID"
+            val rawEditToken = "$publicId.editToken"
+            val bookshelf = Bookshelf(id = 1L, name = "Test bookshelf", publicId = publicId, editTokenHash = "editTokenHash")
 
-            val result = bookshelfService.getBookshelfByToken(bookshelf.editToken)
+            given(bookshelfRepository.findByPublicId(bookshelf.publicId)).willReturn(bookshelf)
+            given(tokenHasher.match(rawEditToken, bookshelf.editTokenHash)).willReturn(true)
+
+            val result = bookshelfService.getBookshelfByToken(rawEditToken)
 
             assertTrue(result.isRight(), "Expected Right when shelf with token exists")
             assertEquals(bookshelf, result.getOrNull(), "Returned bookshelf should match repository output")
         }
 
         @Test
-        fun `getBookshelfByToken returns Left when not found`() {
-            given(bookshelfRepository.findByEditToken("notValidToken")).willReturn(null)
+        fun `getBookshelfByToken returns Left when invalid token`() {
+            val publicId = "publicID"
+            val bookshelf = Bookshelf(id = 1L, name = "Test bookshelf", publicId = publicId, editTokenHash = "editTokenHash")
 
-            val result = bookshelfService.getBookshelfByToken("notValidToken")
+            given(bookshelfRepository.findByPublicId(bookshelf.publicId)).willReturn(bookshelf)
+            given(tokenHasher.match("$publicId.notValidToken", bookshelf.editTokenHash)).willReturn(false)
+
+            val result = bookshelfService.getBookshelfByToken("$publicId.notValidToken")
 
             assertTrue(result.isLeft(), "Expected Left result when invalid edit token")
             assertEquals(
-                BookshelfError.NotFoundByToken("notValidToken"),
+                BookshelfError.NotFoundByToken("$publicId.notValidToken"),
                 result.leftOrNull(),
                 "Expected bookshelf NotFoundByToken error variant",
             )
+        }
+
+        @Test
+        fun `getBookshelfByToken returns Left when bookshelf not found`() {
+            val nonExistentPublicId = "invalidPublicId"
+            given(bookshelfRepository.findByPublicId(nonExistentPublicId)).willReturn(null)
+
+            val result = bookshelfService.getBookshelfByToken("$nonExistentPublicId.notValidToken")
+
+            assertTrue(result.isLeft(), "Expected Left result when invalid edit token")
+            assertEquals(
+                BookshelfError.NotFoundByPublicId(nonExistentPublicId),
+                result.leftOrNull(),
+                "Expected bookshelf NotFoundByPublicId error variant",
+            )
+        }
+    }
+
+    @Nested
+    inner class CreateBookshelf {
+        @Test
+        fun `createBookshelf creates new entity with all required fields`() {
+            val dtoName = "Test bookshelf"
+            val dtoDescription = " Test desc"
+            val editTokenHash = "editTokenHash"
+            val savedBookshelf =
+                Bookshelf(name = dtoName, description = dtoDescription, publicId = "publicID", editTokenHash = editTokenHash)
+
+            given(tokenHasher.hash(any<String>())).willReturn(editTokenHash)
+            given(bookshelfRepository.save(any<Bookshelf>())).willReturn(savedBookshelf)
+
+            val (resultRawEditToken, resultBookshelf) = bookshelfService.createBookshelf(dtoName, dtoDescription)
+
+            assertEquals(savedBookshelf, resultBookshelf, "Expected saved bookshelf to be returned")
+            val parts = resultRawEditToken.split(".")
+            assertEquals(2, parts.size, "Raw edit token should have 2 parts separated by ';'")
+            assertTrue(parts[0].length in 20..22, "publicId part should look like a NanoId")
+            assertDoesNotThrow("Second part should be a valid UUID") {
+                UUID.fromString(parts[1])
+            }
+        }
+    }
+
+    @Nested
+    inner class VerifyToken {
+        @Test
+        fun `verifyToken returns true when tokens match`() {
+            val validEditToken = "editToken"
+            val bookshelf = Bookshelf(id = 1L, name = "Test bookshelf", publicId = "publicId", editTokenHash = "editTokenHash")
+
+            given(tokenHasher.match(validEditToken, bookshelf.editTokenHash)).willReturn(true)
+
+            val result = bookshelfService.verifyToken(bookshelf, validEditToken)
+
+            assertTrue(result, "verifyToken should return true when the provided token matches the stored hash")
+        }
+
+        @Test
+        fun `verifyToken returns false when tokens do not match`() {
+            val invalidEditToken = "invalidEditToken"
+            val bookshelf = Bookshelf(id = 1L, name = "Test bookshelf", publicId = "publicId", editTokenHash = "editTokenHash")
+
+            given(tokenHasher.match(invalidEditToken, bookshelf.editTokenHash)).willReturn(false)
+
+            val result = bookshelfService.verifyToken(bookshelf, invalidEditToken)
+
+            assertFalse(result, "verifyToken should return false when the provided token does not match the stored hash")
         }
     }
 
@@ -119,7 +206,8 @@ class BookshelfServiceTest {
     inner class SaveBookshelf {
         @Test
         fun `saveBookshelf saves and returns persisted entity`() {
-            val newBookshelf = Bookshelf(name = "Test bookshelf", description = "Test desc")
+            val newBookshelf =
+                Bookshelf(name = "Test bookshelf", description = "Test desc", publicId = "publicID", editTokenHash = "editTokenHash")
             val savedBookshelf = newBookshelf.copy(id = 100L)
             given(bookshelfRepository.save(any<Bookshelf>())).willReturn(savedBookshelf)
 
@@ -133,7 +221,7 @@ class BookshelfServiceTest {
     inner class DeleteBookshelf {
         @Test
         fun `deleteBookshelf deletes shelf and its books when found`() {
-            val bookshelf = Bookshelf(id = 10L, publicId = "publicId", name = "My Shelf")
+            val bookshelf = Bookshelf(id = 10L, publicId = "publicId", name = "My Shelf", editTokenHash = "editTokenHash")
             given(bookshelfRepository.findByPublicId(bookshelf.publicId)).willReturn(bookshelf)
             given(bookService.deleteBooksInBookshelf(bookshelf.id)).willReturn(5L)
 


### PR DESCRIPTION
…f ownership

- Added dependencies for `spring-security-crypto` and BouncyCastle (`bcprov-jdk18on`) to enable Argon2 hashing
- Implemented `TokenHasher` using Argon2PasswordEncoder for secure, salted hashing
- Updated edit token design: now generated as a composite string `{publicId}.{UUID}` for unique, collision-resistant identification
- Only hashed `editTokenHash` is stored in the database; raw token returned once upon creation
- Updated `BookshelfService` and related tests to handle the new generation, hashing, and verification flow