### PR TITLE
Improve modal UX, numeric input handling, and safe book updates

### DIFF
--- a/frontend/src/components/commons/BookCard.tsx
+++ b/frontend/src/components/commons/BookCard.tsx
@@ -43,6 +43,7 @@ export const BookCard: FC<BookCardProps> = ({ book, canEdit }) => {
         editToken,
         id,
         {
+          ...book,
           favorite: !favorite,
         },
       );

--- a/frontend/src/components/commons/book/BookMetadata.tsx
+++ b/frontend/src/components/commons/book/BookMetadata.tsx
@@ -49,7 +49,7 @@ export const BookMetadata: FC<BookMetadataProps> = ({
           type="number"
           placeholder={t("placeholders.enterPages")}
           error={errors.pages?.message}
-          register={register("pages")}
+          register={register("pages", { valueAsNumber: true })}
         />
         <Detail
           label={t("bookPage.publisher")}
@@ -81,10 +81,11 @@ export const BookMetadata: FC<BookMetadataProps> = ({
           label={t("bookPage.isbn13")}
           value={book.isbn13}
           mode={mode}
-          type="text"
+          type="number"
           placeholder={t("placeholders.enterIsbn13")}
           error={errors.isbn13?.message}
           register={register("isbn13")}
+          clampNumberToInt32={false}
         />
       </div>
     </section>

--- a/frontend/src/components/commons/book/Detail.tsx
+++ b/frontend/src/components/commons/book/Detail.tsx
@@ -12,7 +12,7 @@ interface DetailProps {
   placeholder?: string;
   error?: string;
   register?: UseFormRegisterReturn;
-  maxNumber?: number;
+  clampNumberToInt32?: boolean;
 }
 
 export const Detail: FC<DetailProps> = ({
@@ -24,8 +24,10 @@ export const Detail: FC<DetailProps> = ({
   placeholder,
   error,
   register,
-  maxNumber = 99999,
+  clampNumberToInt32 = true,
 }) => {
+  const MAX_INT_32 = 2_147_483_647;
+
   if (mode === "view") {
     return (
       <div className="flex items-baseline justify-between border-b border-gray-100 pb-1">
@@ -55,12 +57,21 @@ export const Detail: FC<DetailProps> = ({
         )}
         {type === "number" && (
           <input
-            type="number"
-            min={0}
-            max={maxNumber}
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
             className={`flex-2 text-end border ${error ? "border-red-500" : "border-gray-300"} rounded-md p-2 text-sm text-gray-900`}
             placeholder={placeholder}
             {...register}
+            onInput={(event) => {
+              const target = event.target as HTMLInputElement;
+              let newValue = target.value.replace(/\D+/g, "");
+              if (clampNumberToInt32 && newValue) {
+                const numericValue = Number(newValue);
+                if (numericValue > MAX_INT_32) newValue = MAX_INT_32.toString();
+              }
+              target.value = newValue;
+            }}
           />
         )}
         {type === "date" && (

--- a/frontend/src/components/modals/ModalBase.tsx
+++ b/frontend/src/components/modals/ModalBase.tsx
@@ -1,4 +1,5 @@
 import { type FC, type ReactNode, useEffect } from "react";
+import CrossIcon from "../../assets/icons/cross.svg?react";
 import { useModal } from "../../hooks/useModal";
 
 interface ModalBaseProps {
@@ -28,9 +29,16 @@ export const ModalBase: FC<ModalBaseProps> = ({
       onClick={closeOnOutsideClick ? closeModal : undefined}
     >
       <div
-        className="bg-white p-6 rounded-xl shadow-xl w-full max-w-md text-center"
+        className="relative bg-white p-6 rounded-xl shadow-xl w-full max-w-md text-center"
         onClick={(event) => event.stopPropagation()}
       >
+        <button
+          className="absolute -top-3 -right-3 p-2 rounded-full bg-white border border-gray-300 shadow-sm hover:bg-gray-100 active:scale-95 transition"
+          onClick={closeModal}
+          aria-label="Close modal"
+        >
+          <CrossIcon className="w-4 h-4 text-gray-700" strokeWidth={4} />
+        </button>
         {children}
       </div>
     </div>

--- a/frontend/src/components/modals/openlibrary/OpenLibraryBookDetails.tsx
+++ b/frontend/src/components/modals/openlibrary/OpenLibraryBookDetails.tsx
@@ -1,7 +1,5 @@
 import { useState, type FC } from "react";
-import CrossIcon from "../../../assets/icons/cross.svg?react";
 import { useLanguage } from "../../../hooks/useLanguage";
-import { useModal } from "../../../hooks/useModal";
 import type { OpenLibraryImportBookDetails } from "../../../types/openlibrary";
 import { Button } from "../../commons/Button";
 
@@ -25,7 +23,6 @@ export const OpenLibraryBookDetails: FC<OpenLibraryBookDetailsProps> = ({
   onConfirm,
 }) => {
   const { t } = useLanguage();
-  const { closeModal } = useModal();
 
   const [selectedFields, setSelectedFields] = useState({
     title: true,
@@ -49,14 +46,7 @@ export const OpenLibraryBookDetails: FC<OpenLibraryBookDetailsProps> = ({
   };
 
   return (
-    <div className="relative">
-      <button
-        onClick={closeModal}
-        aria-label={t("common.close")}
-        className="absolute top-0 right-0 text-gray-700 hover:text-gray-900 hover:bg-gray-200 rounded-xl p-1 transition-colors active:scale-95"
-      >
-        <CrossIcon width={22} height={22} strokeWidth={2.5} />
-      </button>
+    <div>
       <h3 className="text-lg font-semibold text-gray-800 border-b border-gray-400 pb-4 mb-4">
         {t("searchOpenLibrary.confirmImportTitle")}
       </h3>

--- a/frontend/src/components/modals/openlibrary/OpenLibrarySearchList.tsx
+++ b/frontend/src/components/modals/openlibrary/OpenLibrarySearchList.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useRef, type FC } from "react";
-import CrossIcon from "../../../assets/icons/cross.svg?react";
 import { useLanguage } from "../../../hooks/useLanguage";
-import { useModal } from "../../../hooks/useModal";
 import type { OpenLibrarySearchBook } from "../../../types/openlibrary";
 import { Button } from "../../commons/Button";
 
@@ -27,7 +25,6 @@ export const OpenLibrarySearchList: FC<OpenLibrarySearchListProps> = ({
   onSelectBook,
 }) => {
   const { t } = useLanguage();
-  const { closeModal } = useModal();
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -46,14 +43,7 @@ export const OpenLibrarySearchList: FC<OpenLibrarySearchListProps> = ({
   }
 
   return (
-    <div className="relative">
-      <button
-        onClick={closeModal}
-        aria-label={t("common.close")}
-        className="absolute top-0 right-0 text-gray-700 hover:text-gray-900 hover:bg-gray-200 rounded-xl p-1 transition-colors active:scale-95"
-      >
-        <CrossIcon width={22} height={22} strokeWidth={2.5} />
-      </button>
+    <div>
       <h2 className="text-xl font-semibold text-text mb-3">
         {t("searchOpenLibrary.title")}
       </h2>


### PR DESCRIPTION
- Added a circular close (X) button to `ModalBase`, positioned outside the top-right corner.
  - Unified close button styling (border, hover, focus states).
- Updated `Detail` component to use `inputMode="numeric"` instead of type=number.
  - Prevents non-digit input and preserves leading zeros.
  - Added optional `capNumberToInt32` (formerly capNumber) to clamp values within 32-bit Int range.
- Prevented Kotlin `400 Malformed JSON` errors by capping all inpus that are Int32 in the backend.
- Fixed favorite toggling in `BookCard` to merge full book object during update, preventing data loss.
- Updated OpenLibrary modals to use consistent close button placement and styling.