### PR TITLE
Create workflow for auto tagging each merge to main

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,0 +1,25 @@
+name: Post Merge Workflow
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  create_tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: ${{ !contains(github.event.head_commit.message, '#notag') }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.75.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BUMP: patch
+          TAG_PREFIX: v


### PR DESCRIPTION
A post-merge GitHub Actions workflow (`post-merge.yml`) to automate Semantic Versioning tags whenever code is pushed or merged into the `main` branch.

This eliminates the need to manually create Git tags, ensuring every deployment or update has a clear, traceable version number.

How it works
--
The workflow reads the merge commit message to determine how the version number should be bumped. It uses the `anothrNick/github-tag-action` to handle the tagging.

**Tagging Rules:**
* **Major Release:** Include `#major` in the commit message (e.g., `v1.0.0` -> `v2.0.0`).
* **Minor Release (New Features):** Include `#minor` in the commit message (e.g., `v1.0.0` -> `v1.1.0`).
* **Patch Release (Bug Fixes):** If **no hashtag** is provided, the workflow defaults to a patch bump (e.g., `v1.0.0` -> `v1.0.1`). 
  * *Note: This ensures automated Dependabot merges are correctly tagged as patches.*
* **Skip Tagging:** Include `#none` in the commit message to bypass the workflow completely (useful for minor documentation updates).

Technical Details
--
* Uses `actions/checkout@v5` with `fetch-depth: 0` to properly read the commit history.
* Runs on `ubuntu-latest`.
* Requires `permissions: contents: write` to allow the GitHub runner to push tags back to the repository.