### PR TITLE
Create year filter

### DIFF
--- a/frontend/src/components/commons/BookshelfVeiw.tsx
+++ b/frontend/src/components/commons/BookshelfVeiw.tsx
@@ -31,12 +31,22 @@ export const BookshelfView: FC<BookshelfViewProps> = ({
     return [...books].sort((a, b) => toTime(b) - toTime(a));
   }, [books]);
   const [filters, setFilters] = useState({
+    year: "",
     genre: "",
     language: "",
     status: "",
     searchQuery: "",
     sort: "",
   });
+
+  const availableYears = useMemo(() => {
+    const years = new Set(
+      books
+        .map((b) => b.finishedAt && new Date(b.finishedAt).getFullYear())
+        .filter(Boolean) as number[],
+    );
+    return [...years].sort((a, b) => b - a).map(String);
+  }, [books]);
 
   const handleFilterChange = (field: string, value: string | boolean) => {
     setFilters((prev) => ({
@@ -47,6 +57,7 @@ export const BookshelfView: FC<BookshelfViewProps> = ({
 
   const handleClearFilters = () => {
     setFilters({
+      year: "",
       genre: "",
       language: "",
       status: "",
@@ -57,6 +68,13 @@ export const BookshelfView: FC<BookshelfViewProps> = ({
 
   const filteredBooks = useMemo(() => {
     let result = [...displayBooks];
+    if (filters.year)
+      result = result.filter((book) => {
+        const bookYear = book.finishedAt
+          ? new Date(book.finishedAt).getFullYear().toString()
+          : "";
+        return bookYear === filters.year;
+      });
     if (filters.genre)
       result = result.filter((book) => book.genre === filters.genre);
     if (filters.language)
@@ -128,6 +146,7 @@ export const BookshelfView: FC<BookshelfViewProps> = ({
       />
       <BookshelfToolbar
         filters={filters}
+        availableYears={availableYears}
         onFilterChange={handleFilterChange}
         onSearchChange={(query) => handleFilterChange("searchQuery", query)}
         onSortChange={(value) => handleFilterChange("sort", value)}

--- a/frontend/src/components/commons/BookshelfVeiw.tsx
+++ b/frontend/src/components/commons/BookshelfVeiw.tsx
@@ -48,6 +48,16 @@ export const BookshelfView: FC<BookshelfViewProps> = ({
     return [...years].sort((a, b) => b - a).map(String);
   }, [books]);
 
+  const availableGenres = useMemo(() => {
+    return [...new Set(books.map((b) => b.genre).filter(Boolean))] as string[];
+  }, [books]);
+
+  const availableLanguages = useMemo(() => {
+    return [
+      ...new Set(books.map((b) => b.language).filter(Boolean)),
+    ] as string[];
+  }, [books]);
+
   const handleFilterChange = (field: string, value: string | boolean) => {
     setFilters((prev) => ({
       ...prev,
@@ -147,6 +157,8 @@ export const BookshelfView: FC<BookshelfViewProps> = ({
       <BookshelfToolbar
         filters={filters}
         availableYears={availableYears}
+        availableGenres={availableGenres}
+        availableLanguages={availableLanguages}
         onFilterChange={handleFilterChange}
         onSearchChange={(query) => handleFilterChange("searchQuery", query)}
         onSortChange={(value) => handleFilterChange("sort", value)}

--- a/frontend/src/components/commons/bookshelf/BookshelfToolbar.tsx
+++ b/frontend/src/components/commons/bookshelf/BookshelfToolbar.tsx
@@ -13,6 +13,40 @@ import {
 
 const ALL_VALUES = "ALL";
 
+const GENRE_TRANSLATION_KEYS = {
+  BIOGRAPHY: "bookshelfToolbar.genreBiography",
+  FANTASY: "bookshelfToolbar.genreFantasy",
+  FICTION: "bookshelfToolbar.genreFiction",
+  HISTORY: "bookshelfToolbar.genreHistory",
+  MYSTERY: "bookshelfToolbar.genreMystery",
+  NONFICTION: "bookshelfToolbar.genreNonFiction",
+  OTHER: "bookshelfToolbar.genreOther",
+  ROMANCE: "bookshelfToolbar.genreRomance",
+  SCIENCE: "bookshelfToolbar.genreScience",
+  SCIFI: "bookshelfToolbar.genreSciFi",
+  TECHNOLOGY: "bookshelfToolbar.genreTechnology",
+  THRILLER: "bookshelfToolbar.genreThriller",
+  UNKNOWN: "bookshelfToolbar.genreUnknown",
+} as const;
+
+const LANGUAGE_TRANSLATION_KEYS = {
+  ARABIC: "bookshelfToolbar.languageArabic",
+  CHINESE: "bookshelfToolbar.languageChinese",
+  ENGLISH: "bookshelfToolbar.languageEnglish",
+  FINNISH: "bookshelfToolbar.languageFinnish",
+  FRENCH: "bookshelfToolbar.languageFrench",
+  GERMAN: "bookshelfToolbar.languageGerman",
+  HINDI: "bookshelfToolbar.languageHindi",
+  ITALIAN: "bookshelfToolbar.languageItalian",
+  JAPANESE: "bookshelfToolbar.languageJapanese",
+  OTHER: "bookshelfToolbar.languageOther",
+  PORTUGUESE: "bookshelfToolbar.languagePortuguese",
+  RUSSIAN: "bookshelfToolbar.languageRussian",
+  SPANISH: "bookshelfToolbar.languageSpanish",
+  SWEDISH: "bookshelfToolbar.languageSwedish",
+  UNKNOWN: "bookshelfToolbar.languageUnknown",
+} as const;
+
 interface BookshelfToolbarProps {
   filters: {
     year?: string;
@@ -23,6 +57,8 @@ interface BookshelfToolbarProps {
     sort?: string;
   };
   availableYears: string[];
+  availableGenres?: string[];
+  availableLanguages?: string[];
   onFilterChange: (field: string, value: string | boolean) => void;
   onSearchChange: (query: string) => void;
   onSortChange: (field: string) => void;
@@ -32,6 +68,8 @@ interface BookshelfToolbarProps {
 export const BookshelfToolbar: FC<BookshelfToolbarProps> = ({
   filters,
   availableYears,
+  availableGenres = [],
+  availableLanguages = [],
   onFilterChange,
   onSearchChange,
   onSortChange,
@@ -86,45 +124,15 @@ export const BookshelfToolbar: FC<BookshelfToolbarProps> = ({
               <SelectItem value={ALL_VALUES}>
                 {t("bookshelfToolbar.allGenres")}
               </SelectItem>
-              <SelectItem value="UNKNOWN">
-                {t("bookshelfToolbar.genreUnknown")}
-              </SelectItem>
-              <SelectItem value="FICTION">
-                {t("bookshelfToolbar.genreFiction")}
-              </SelectItem>
-              <SelectItem value="NON-FICTION">
-                {t("bookshelfToolbar.genreNonFiction")}
-              </SelectItem>
-              <SelectItem value="SCI-FI">
-                {t("bookshelfToolbar.genreSciFi")}
-              </SelectItem>
-              <SelectItem value="FANTASY">
-                {t("bookshelfToolbar.genreFantasy")}
-              </SelectItem>
-              <SelectItem value="BIOGRAPHY">
-                {t("bookshelfToolbar.genreBiography")}
-              </SelectItem>
-              <SelectItem value="HISTORY">
-                {t("bookshelfToolbar.genreHistory")}
-              </SelectItem>
-              <SelectItem value="MYSTERY">
-                {t("bookshelfToolbar.genreMystery")}
-              </SelectItem>
-              <SelectItem value="THRILLER">
-                {t("bookshelfToolbar.genreThriller")}
-              </SelectItem>
-              <SelectItem value="ROMANCE">
-                {t("bookshelfToolbar.genreRomance")}
-              </SelectItem>
-              <SelectItem value="SCIENCE">
-                {t("bookshelfToolbar.genreScience")}
-              </SelectItem>
-              <SelectItem value="TECHNOLOGY">
-                {t("bookshelfToolbar.genreTechnology")}
-              </SelectItem>
-              <SelectItem value="OTHER">
-                {t("bookshelfToolbar.genreOther")}
-              </SelectItem>
+              {availableGenres.map((genre) => (
+                <SelectItem key={genre} value={genre}>
+                  {t(
+                    GENRE_TRANSLATION_KEYS[
+                      genre as keyof typeof GENRE_TRANSLATION_KEYS
+                    ],
+                  )}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
           <Select
@@ -140,51 +148,15 @@ export const BookshelfToolbar: FC<BookshelfToolbarProps> = ({
               <SelectItem value={ALL_VALUES}>
                 {t("bookshelfToolbar.allLanguages")}
               </SelectItem>
-              <SelectItem value="UNKNOWN">
-                {t("bookshelfToolbar.languageUnknown")}
-              </SelectItem>
-              <SelectItem value="ENGLISH">
-                {t("bookshelfToolbar.languageEnglish")}
-              </SelectItem>
-              <SelectItem value="FINNISH">
-                {t("bookshelfToolbar.languageFinnish")}
-              </SelectItem>
-              <SelectItem value="GERMAN">
-                {t("bookshelfToolbar.languageGerman")}
-              </SelectItem>
-              <SelectItem value="FRENCH">
-                {t("bookshelfToolbar.languageFrench")}
-              </SelectItem>
-              <SelectItem value="SPANISH">
-                {t("bookshelfToolbar.languageSpanish")}
-              </SelectItem>
-              <SelectItem value="SWEDISH">
-                {t("bookshelfToolbar.languageSwedish")}
-              </SelectItem>
-              <SelectItem value="ITALIAN">
-                {t("bookshelfToolbar.languageItalian")}
-              </SelectItem>
-              <SelectItem value="JAPANESE">
-                {t("bookshelfToolbar.languageJapanese")}
-              </SelectItem>
-              <SelectItem value="PORTUGUESE">
-                {t("bookshelfToolbar.languagePortuguese")}
-              </SelectItem>
-              <SelectItem value="RUSSIAN">
-                {t("bookshelfToolbar.languageRussian")}
-              </SelectItem>
-              <SelectItem value="CHINESE">
-                {t("bookshelfToolbar.languageChinese")}
-              </SelectItem>
-              <SelectItem value="HINDI">
-                {t("bookshelfToolbar.languageHindi")}
-              </SelectItem>
-              <SelectItem value="ARABIC">
-                {t("bookshelfToolbar.languageArabic")}
-              </SelectItem>
-              <SelectItem value="OTHER">
-                {t("bookshelfToolbar.languageOther")}
-              </SelectItem>
+              {availableLanguages.map((language) => (
+                <SelectItem key={language} value={language}>
+                  {t(
+                    LANGUAGE_TRANSLATION_KEYS[
+                      language as keyof typeof LANGUAGE_TRANSLATION_KEYS
+                    ],
+                  )}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
           <Select

--- a/frontend/src/components/commons/bookshelf/BookshelfToolbar.tsx
+++ b/frontend/src/components/commons/bookshelf/BookshelfToolbar.tsx
@@ -11,6 +11,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
+const ALL_VALUES = "ALL";
+
 interface BookshelfToolbarProps {
   filters: {
     year?: string;
@@ -53,12 +55,17 @@ export const BookshelfToolbar: FC<BookshelfToolbarProps> = ({
         <div className="flex flex-wrap gap-2">
           <Select
             value={filters.year || ""}
-            onValueChange={(value) => onFilterChange("year", value)}
+            onValueChange={(value) =>
+              onFilterChange("year", value === ALL_VALUES ? "" : value)
+            }
           >
             <SelectTrigger className="w-[160px]">
               <SelectValue placeholder={t("bookshelfToolbar.yearFinished")} />
             </SelectTrigger>
             <SelectContent>
+              <SelectItem value={ALL_VALUES}>
+                {t("bookshelfToolbar.allYears")}
+              </SelectItem>
               {availableYears.map((year) => (
                 <SelectItem key={year} value={year}>
                   {year}
@@ -68,12 +75,17 @@ export const BookshelfToolbar: FC<BookshelfToolbarProps> = ({
           </Select>
           <Select
             value={filters.genre || ""}
-            onValueChange={(value) => onFilterChange("genre", value)}
+            onValueChange={(value) =>
+              onFilterChange("genre", value === ALL_VALUES ? "" : value)
+            }
           >
             <SelectTrigger className="w-[180px]">
               <SelectValue placeholder={t("bookshelfToolbar.allGenres")} />
             </SelectTrigger>
             <SelectContent>
+              <SelectItem value={ALL_VALUES}>
+                {t("bookshelfToolbar.allGenres")}
+              </SelectItem>
               <SelectItem value="UNKNOWN">
                 {t("bookshelfToolbar.genreUnknown")}
               </SelectItem>
@@ -117,12 +129,17 @@ export const BookshelfToolbar: FC<BookshelfToolbarProps> = ({
           </Select>
           <Select
             value={filters.language || ""}
-            onValueChange={(value) => onFilterChange("language", value)}
+            onValueChange={(value) =>
+              onFilterChange("language", value === ALL_VALUES ? "" : value)
+            }
           >
             <SelectTrigger className="w-[200px]">
               <SelectValue placeholder={t("bookshelfToolbar.allLanguages")} />
             </SelectTrigger>
             <SelectContent>
+              <SelectItem value={ALL_VALUES}>
+                {t("bookshelfToolbar.allLanguages")}
+              </SelectItem>
               <SelectItem value="UNKNOWN">
                 {t("bookshelfToolbar.languageUnknown")}
               </SelectItem>
@@ -172,12 +189,17 @@ export const BookshelfToolbar: FC<BookshelfToolbarProps> = ({
           </Select>
           <Select
             value={filters.status || ""}
-            onValueChange={(value) => onFilterChange("status", value)}
+            onValueChange={(value) =>
+              onFilterChange("status", value === ALL_VALUES ? "" : value)
+            }
           >
             <SelectTrigger className="w-[160px]">
               <SelectValue placeholder={t("bookshelfToolbar.allStatuses")} />
             </SelectTrigger>
             <SelectContent>
+              <SelectItem value={ALL_VALUES}>
+                {t("bookshelfToolbar.allStatuses")}
+              </SelectItem>
               <SelectItem value="WISHLIST">
                 {t("bookshelfToolbar.statusWishlist")}
               </SelectItem>
@@ -191,12 +213,17 @@ export const BookshelfToolbar: FC<BookshelfToolbarProps> = ({
           </Select>
           <Select
             value={filters.sort || ""}
-            onValueChange={(value) => onSortChange(value)}
+            onValueChange={(value) =>
+              onSortChange(value === ALL_VALUES ? "" : value)
+            }
           >
             <SelectTrigger className="w-[220px]">
               <SelectValue placeholder={t("bookshelfToolbar.sortBy")} />
             </SelectTrigger>
             <SelectContent>
+              <SelectItem value={ALL_VALUES}>
+                {t("bookshelfToolbar.noSorting")}
+              </SelectItem>
               <SelectItem value="favoritesFirst">
                 {t("bookshelfToolbar.sortFavoritesFirst")}
               </SelectItem>

--- a/frontend/src/components/commons/bookshelf/BookshelfToolbar.tsx
+++ b/frontend/src/components/commons/bookshelf/BookshelfToolbar.tsx
@@ -13,12 +13,14 @@ import {
 
 interface BookshelfToolbarProps {
   filters: {
+    year?: string;
     genre?: string;
     language?: string;
     status?: string;
     searchQuery?: string;
     sort?: string;
   };
+  availableYears: string[];
   onFilterChange: (field: string, value: string | boolean) => void;
   onSearchChange: (query: string) => void;
   onSortChange: (field: string) => void;
@@ -27,6 +29,7 @@ interface BookshelfToolbarProps {
 
 export const BookshelfToolbar: FC<BookshelfToolbarProps> = ({
   filters,
+  availableYears,
   onFilterChange,
   onSearchChange,
   onSortChange,
@@ -48,6 +51,21 @@ export const BookshelfToolbar: FC<BookshelfToolbarProps> = ({
           className="flex-1 min-w-[260px]"
         />
         <div className="flex flex-wrap gap-2">
+          <Select
+            value={filters.year || ""}
+            onValueChange={(value) => onFilterChange("year", value)}
+          >
+            <SelectTrigger className="w-[160px]">
+              <SelectValue placeholder={t("bookshelfToolbar.yearFinished")} />
+            </SelectTrigger>
+            <SelectContent>
+              {availableYears.map((year) => (
+                <SelectItem key={year} value={year}>
+                  {year}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
           <Select
             value={filters.genre || ""}
             onValueChange={(value) => onFilterChange("genre", value)}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -41,6 +41,7 @@
   },
   "bookshelfToolbar": {
     "yearFinished": "Year Finished",
+    "allYears": "All Years",
     "allGenres": "All Genres",
     "allLanguages": "All Languages",
     "allStatuses": "All Statuses",
@@ -78,6 +79,7 @@
     "languageUnknown": "Unknown Language",
     "searchPlaceholder": "Search by title, author, or ISBN...",
     "sortBy": "Sort by:",
+    "noSorting": "No Sorting",
     "sortByRatingAsc": "Rating (Low to High)",
     "sortByRatingDesc": "Rating (High to Low)",
     "sortFavoritesFirst": "Favorites First",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -40,6 +40,7 @@
     "startedAt": "Started At"
   },
   "bookshelfToolbar": {
+    "yearFinished": "Year Finished",
     "allGenres": "All Genres",
     "allLanguages": "All Languages",
     "allStatuses": "All Statuses",


### PR DESCRIPTION
- Added `year` filter to the `BookshelfToolbar` that filters books based on the year the book was finished
- `Year` dropdown only shows years that have books finished in that year, derived dynamically from the bookshelf data
- `Genre` and `language` dropdowns now only show options that have entries in the current bookshelf, rather than all possible values
- Added `ALL_VALUES` entry as the first item in each dropdown to allow resetting individual filters
- Mapped `genre` and `language` filter values to their correct translation keys using explicit lookup maps