### PR TITLE
Add shadcn laoding spinner

### DIFF
--- a/frontend/src/components/commons/Topbar.tsx
+++ b/frontend/src/components/commons/Topbar.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { useLanguage } from "../../hooks/useLanguage";
 import { useModal } from "../../hooks/useModal";
 import { useMyBookshelf } from "../../hooks/useMyBookshelf";
+import { Spinner } from "../ui/spinner";
 import { deleteBookshelf } from "@/api/bookshelves";
 import { Button } from "@/components/ui/button";
 import {
@@ -16,7 +17,8 @@ import {
 
 export const Topbar: FC = () => {
   const { t } = useLanguage();
-  const { bookshelf, editToken, clearBookshelf } = useMyBookshelf();
+  const { bookshelf, editToken, isInitialized, isLoading, clearBookshelf } =
+    useMyBookshelf();
   const { openModal, closeModal } = useModal();
   const navigate = useNavigate();
 
@@ -79,7 +81,7 @@ export const Topbar: FC = () => {
           <DropdownMenuTrigger asChild>
             <Button
               variant="secondary"
-              className="flex items-center gap-2 bg-muted text-foreground hover:bg-muted/80 hover:cursor-pointer"
+              className="flex items-center gap-2 bg-muted text-foreground hover:bg-muted/80 hover:cursor-pointer min-w-[170px]"
             >
               <Library className="w-4 h-4 text-foreground" />
               {t("button.myBookshelf")}
@@ -117,8 +119,10 @@ export const Topbar: FC = () => {
         <Button
           variant="secondary"
           onClick={() => openModal("ENTER_TOKEN", {})}
-          className="bg-muted text-foreground hover:bg-muted/80 hover:cursor-pointer"
+          className="bg-muted text-foreground hover:bg-muted/80 hover:cursor-pointer min-w-[170px]"
+          disabled={!isInitialized || isLoading}
         >
+          {(!isInitialized || isLoading) && <Spinner className="size-4" />}
           {t("button.myBookshelf")}
         </Button>
       )}

--- a/frontend/src/components/modals/ExportBooksModal.tsx
+++ b/frontend/src/components/modals/ExportBooksModal.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, type FC } from "react";
 import { toast } from "sonner";
 import { ModalBase } from "./ModalBase";
 import { useModal } from "../../hooks/useModal";
+import { Spinner } from "../ui/spinner";
 import { exportBooksFromBookshelf } from "@/api/bookshelves";
 import { Button } from "@/components/ui/button";
 import {
@@ -95,7 +96,9 @@ export const ExportBooksModal: FC<ExportBooksModalProps> = ({
           aria-live="polite"
           className="flex flex-col items-center justify-center py-10 gap-3"
         >
-          <div className="h-10 w-10 border-4 border-muted-foreground border-t-transparent rounded-full animate-spin" />
+          <div className="flex items-center justify-center">
+            <Spinner className="size-12" />
+          </div>
           <p className="text-muted-foreground">{t("common.loading")}</p>
         </div>
       ) : (

--- a/frontend/src/components/modals/ImportBooksModal.tsx
+++ b/frontend/src/components/modals/ImportBooksModal.tsx
@@ -5,6 +5,7 @@ import { importBooksToBookshelf } from "../../api/bookshelves";
 import { useLanguage } from "../../hooks/useLanguage";
 import { useModal } from "../../hooks/useModal";
 import { useMyBookshelf } from "../../hooks/useMyBookshelf";
+import { Spinner } from "../ui/spinner";
 import { Button } from "@/components/ui/button";
 import {
   DialogTitle,
@@ -75,7 +76,9 @@ export const ImportBooksModal: FC = () => {
           aria-live="polite"
           className="flex flex-col items-center justify-center py-10 gap-3"
         >
-          <div className="h-10 w-10 border-4 border-muted-foreground border-t-transparent rounded-full animate-spin" />
+          <div className="flex items-center justify-center">
+            <Spinner className="size-12" />
+          </div>
           <p className="text-muted-foreground">{t("common.loading")}</p>
         </div>
       ) : (

--- a/frontend/src/components/modals/openlibrary/OpenLibrarySearchList.tsx
+++ b/frontend/src/components/modals/openlibrary/OpenLibrarySearchList.tsx
@@ -8,6 +8,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
 
 interface OpenLibrarySearchListProps {
   query: string;
@@ -89,7 +90,9 @@ export const OpenLibrarySearchList: FC<OpenLibrarySearchListProps> = ({
           aria-live="polite"
           className="flex flex-col items-center justify-center py-10 gap-3"
         >
-          <div className="h-10 w-10 border-4 border-muted-foreground border-t-transparent rounded-full animate-spin" />
+          <div className="flex items-center justify-center">
+            <Spinner className="size-12" />
+          </div>
           <p className="text-muted-foreground">{t("common.loading")}</p>
         </div>
       )}

--- a/frontend/src/components/ui/spinner.tsx
+++ b/frontend/src/components/ui/spinner.tsx
@@ -1,0 +1,16 @@
+import { Loader2Icon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+  return (
+    <Loader2Icon
+      role="status"
+      aria-label="Loading"
+      className={cn("size-4 animate-spin", className)}
+      {...props}
+    />
+  );
+}
+
+export { Spinner };

--- a/frontend/src/contexts/MyBookshelfContext.ts
+++ b/frontend/src/contexts/MyBookshelfContext.ts
@@ -7,6 +7,7 @@ export interface MyBookshelfContextValue {
   books: Book[];
   editToken: string | null;
   isInitialized: boolean;
+  isLoading: boolean;
   setBookshelf: (bookshelf: Bookshelf | null) => void;
   setBooks: (books: Book[]) => void;
   setEditToken: (editToken: string | null) => void;

--- a/frontend/src/contexts/MyBookshelfProvider.tsx
+++ b/frontend/src/contexts/MyBookshelfProvider.tsx
@@ -16,12 +16,14 @@ export const MyBookshelfProvider = ({ children }: { children: ReactNode }) => {
   const [bookshelf, setBookshelf] = useState<Bookshelf | null>(null);
   const [books, setBooks] = useState<Book[]>([]);
   const [isInitialized, setIsInitialized] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   const { t } = useLanguage();
 
   const refreshBookshelf = async () => {
     if (!editToken) return;
 
+    setIsLoading(true);
     try {
       const fetchedBookshelf = await getBookshelfByToken(editToken);
       const fetchedBooks = await getBooksInBookshelfByToken(editToken);
@@ -30,6 +32,8 @@ export const MyBookshelfProvider = ({ children }: { children: ReactNode }) => {
     } catch (error) {
       console.error("Failed to refresh bookshelf:", error);
       toast.error(t("toast.failedToRefreshBookshelf"));
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -37,6 +41,7 @@ export const MyBookshelfProvider = ({ children }: { children: ReactNode }) => {
     setBookshelf(null);
     setBooks([]);
     setEditToken(null);
+    setIsLoading(false);
     localStorage.removeItem("editToken");
   };
 
@@ -56,6 +61,7 @@ export const MyBookshelfProvider = ({ children }: { children: ReactNode }) => {
     books,
     editToken,
     isInitialized,
+    isLoading,
     setBookshelf,
     setBooks,
     setEditToken,

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -252,6 +252,7 @@
     "noBookshelfToDelete": "No bookshelf to delete.",
     "noPermissionToEditBook": "You do not have permission to edit this book.",
     "noTokenFound": "No token found.",
+    "noBookshelfFound": "No bookshelf found.",
     "nothingToCopy": "Nothing to copy.",
     "nothingToDownload": "Nothing to download.",
     "nothingToImport": "Nothing to import.",

--- a/frontend/src/pages/BookPage.tsx
+++ b/frontend/src/pages/BookPage.tsx
@@ -22,6 +22,7 @@ import type { Book } from "../types/book";
 import type { BookPageMode } from "../types/book-page-mode";
 import { bookFormSchema, type BookForm } from "../validation/bookFormSchema";
 import { Form } from "@/components/ui/form";
+import { Spinner } from "@/components/ui/spinner";
 
 interface BookPageProps {
   mode: BookPageMode;
@@ -166,8 +167,6 @@ export const BookPage: FC<BookPageProps> = ({ mode }) => {
     }
   };
 
-  if (loading) return <div>{t("common.loading")}</div>;
-
   return (
     <main className="max-w-5xl mx-auto pt-10 pb-6 px-6">
       <Form {...form}>
@@ -175,23 +174,34 @@ export const BookPage: FC<BookPageProps> = ({ mode }) => {
           onSubmit={handleSubmit(onSubmit)}
           className="bg-card rounded-2xl shadow-xl p-8"
         >
-          <BookPageHeader book={book} mode={mode} form={form} />
-          <BookMetadata book={book} mode={mode} form={form} />
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-10 mb-10">
-            <BookReadingDetails book={book} mode={mode} form={form} />
-            <BookPersonalStats book={book} mode={mode} form={form} />
-          </div>
-          <BookPersonalNotes book={book} mode={mode} form={form} />
-          <BookPageActions
-            book={book}
-            mode={mode}
-            canEdit={canEdit}
-            bookId={bookId}
-            editToken={editToken}
-            refreshBookshelf={refreshBookshelf}
-            reset={reset}
-            isSubmitting={isSubmitting}
-          />
+          {loading || !isInitialized ? (
+            <div className="flex flex-col items-center justify-center h-[calc(100vh-24rem)] ">
+              <Spinner className="size-24" />
+              <p className="text-2xl text-muted-foreground">
+                {t("common.loading")}
+              </p>
+            </div>
+          ) : (
+            <>
+              <BookPageHeader book={book} mode={mode} form={form} />
+              <BookMetadata book={book} mode={mode} form={form} />
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-10 mb-10">
+                <BookReadingDetails book={book} mode={mode} form={form} />
+                <BookPersonalStats book={book} mode={mode} form={form} />
+              </div>
+              <BookPersonalNotes book={book} mode={mode} form={form} />
+              <BookPageActions
+                book={book}
+                mode={mode}
+                canEdit={canEdit}
+                bookId={bookId}
+                editToken={editToken}
+                refreshBookshelf={refreshBookshelf}
+                reset={reset}
+                isSubmitting={isSubmitting}
+              />
+            </>
+          )}
         </form>
       </Form>
     </main>

--- a/frontend/src/pages/MyBookshelf.tsx
+++ b/frontend/src/pages/MyBookshelf.tsx
@@ -4,9 +4,11 @@ import { toast } from "sonner";
 import { BookshelfView } from "../components/commons/BookshelfVeiw";
 import { useLanguage } from "../hooks/useLanguage";
 import { useMyBookshelf } from "../hooks/useMyBookshelf";
+import { Spinner } from "@/components/ui/spinner";
 
 export const MyBookshelf: FC = () => {
-  const { editToken, bookshelf, books, clearBookshelf } = useMyBookshelf();
+  const { editToken, bookshelf, books, isLoading, clearBookshelf } =
+    useMyBookshelf();
   const { t } = useLanguage();
   const navigate = useNavigate();
 
@@ -17,8 +19,19 @@ export const MyBookshelf: FC = () => {
     }
   }, [editToken, navigate, t]);
 
+  if (isLoading) {
+    return (
+      <div className="flex flex-col items-center justify-center h-[calc(100vh-8rem)]">
+        <Spinner className="size-24" />
+        <p className="text-2xl text-muted-foreground">{t("common.loading")}</p>
+      </div>
+    );
+  }
+
   if (!bookshelf) {
-    return <div>{t("common.loading")}</div>;
+    toast.error(t("toast.noBookshelfFound"));
+    navigate("/", { replace: true });
+    return null;
   }
 
   return (

--- a/frontend/src/pages/PublicBookshelf.tsx
+++ b/frontend/src/pages/PublicBookshelf.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import { BookshelfView } from "../components/commons/BookshelfVeiw";
 import { useLanguage } from "../hooks/useLanguage";
 import { usePublicBookshelf } from "../hooks/usePublicBookshelf";
+import { Spinner } from "@/components/ui/spinner";
 
 export const PublicBookshelf: FC = () => {
   const { publicId } = useParams<{ publicId: string }>();
@@ -19,7 +20,13 @@ export const PublicBookshelf: FC = () => {
   }, [error, navigate]);
 
   if (!publicId) return <div>{t("common.invalidBookshelfPublicId")}</div>;
-  if (loading) return <div>{t("common.loading")}</div>;
+  if (loading)
+    return (
+      <div className="flex flex-col items-center justify-center h-[calc(100vh-8rem)] ">
+        <Spinner className="size-24" />
+        <p className="text-2xl text-muted-foreground">{t("common.loading")}</p>
+      </div>
+    );
   if (!bookshelf) return <div>{t("common.bookshelfNotFound")}</div>;
 
   return <BookshelfView bookshelf={bookshelf} books={books} canEdit={false} />;


### PR DESCRIPTION
- Install ShadCN `Spinner` and replace all existing loading states with it
- Add `isLoading` state to `MyBookshelfContext` and display `spinner` when accessing the bookshelf from context
- Add loading state to `MyBookshelf` on `Topbar` and make the button width consistent between states
  - Prevents layout shifts and opening `CreateBooksheldModal` when context is only loading