### PR TITLE
Add job name and timeout to tagging workflow

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   create_tag:
+    name: Create Tag After Merge
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
- **Added name:** Create Tag After Merge for better visibility in the GitHub Actions UI.
- **Added timeout-minutes:** 5 to prevent the job from hanging indefinitely in the event of a runner issue or network failure.