### PR TITLE
Improve transaction integrity and error handling

### DIFF
--- a/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/controller/BookshelfController.kt
+++ b/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/controller/BookshelfController.kt
@@ -367,13 +367,26 @@ class BookshelfController(
                         )
                 }
 
-                val deletedBookCount = bookshelfService.deleteBookshelf(bookshelf.value.publicId).getOrNull()!!
-                val payload =
-                    DeleteBookshelfResult(
-                        deletedBookshelfPublicId = bookshelf.value.publicId,
-                        deletedBooksCount = deletedBookCount,
-                    )
-                ResponseEntity.ok(ApiResponse(data = payload))
+                when (val result = bookshelfService.deleteBookshelf(bookshelf.value.publicId)) {
+                    is Either.Right -> {
+                        val payload =
+                            DeleteBookshelfResult(
+                                deletedBookshelfPublicId = bookshelf.value.publicId,
+                                deletedBooksCount = result.value,
+                            )
+                        ResponseEntity.ok(ApiResponse(data = payload))
+                    }
+                    is Either.Left ->
+                        ResponseEntity.status(500).body(
+                            ApiResponse(
+                                error =
+                                    ErrorResponse(
+                                        "Unexpected error deleting bookshelf $publicId",
+                                        ErrorCodes.INTERNAL_ERROR,
+                                    ),
+                            ),
+                        )
+                }
             }
             is Either.Left ->
                 ResponseEntity
@@ -394,7 +407,7 @@ class BookshelfController(
     fun deleteBook(
         @PathVariable publicId: String,
         @PathVariable bookId: Long,
-        @RequestHeader("X-BOOKSHELF-TOKEN", required = false) token: String?,
+        @RequestHeader(X_BOOKSHELF_TOKEN, required = false) token: String?,
     ): ResponseEntity<ApiResponse<Long>> {
         return when (val bookshelf = bookshelfService.getBookshelfByPublicId(publicId)) {
             is Either.Right -> {
@@ -412,6 +425,25 @@ class BookshelfController(
                                     ),
                             ),
                         )
+                }
+
+                val bookEither = bookService.getBookById(bookId)
+                if (bookEither !is Either.Right ||
+                    bookEither.value.bookshelfId != bookshelf.value.id
+                ) {
+                    logger.warn {
+                        "${logContext("deleteBook")} Book not found in bookshelf: " +
+                            "bookId=$bookId, publicId=$publicId"
+                    }
+                    return ResponseEntity.status(404).body(
+                        ApiResponse(
+                            error =
+                                ErrorResponse(
+                                    "Book with id $bookId not found in bookshelf $publicId",
+                                    ErrorCodes.BOOK_NOT_FOUND,
+                                ),
+                        ),
+                    )
                 }
 
                 when (val response = bookService.deleteBook(bookId)) {

--- a/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/controller/advice/ErrorCodes.kt
+++ b/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/controller/advice/ErrorCodes.kt
@@ -6,4 +6,5 @@ enum class ErrorCodes {
     INVALID_API_KEY,
     FORBIDDEN,
     VALIDATION_ERROR,
+    INTERNAL_ERROR,
 }

--- a/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/repository/BookRepository.kt
+++ b/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/repository/BookRepository.kt
@@ -3,6 +3,8 @@ package io.github.tyostokarry.bookshelf.repository
 import io.github.tyostokarry.bookshelf.entity.Book
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.transaction.annotation.Transactional
 
 /**
@@ -31,4 +33,11 @@ interface BookRepository : JpaRepository<Book, Long> {
     @Modifying
     @Transactional
     fun deleteByBookshelfId(bookshelfId: Long): Long
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Book b WHERE b.id = :id")
+    fun deleteByIdIfExists(
+        @Param("id") id: Long,
+    ): Int
 }

--- a/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/service/BookService.kt
+++ b/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/service/BookService.kt
@@ -78,15 +78,16 @@ class BookService(
     }
 
     @Transactional
-    fun deleteBook(id: Long): Either<BookError, Long> =
-        if (bookRepository.existsById(id)) {
-            bookRepository.deleteById(id)
+    fun deleteBook(id: Long): Either<BookError, Long> {
+        val deleted = bookRepository.deleteByIdIfExists(id)
+        return if (deleted > 0) {
             logger.info { "${logContext("deleteBook")} Deleted book: id=$id" }
             id.right()
         } else {
             logger.warn { "${logContext("deleteBook")} Delete failed — book not found: id=$id" }
             BookError.NotFound(id).left()
         }
+    }
 
     @Transactional
     fun deleteBooksInBookshelf(bookshelfId: Long): Long {

--- a/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/service/BookshelfService.kt
+++ b/backend/src/main/kotlin/io/github/tyostokarry/bookshelf/service/BookshelfService.kt
@@ -13,6 +13,7 @@ import io.github.tyostokarry.bookshelf.util.logContext
 import io.github.tyostokarry.bookshelf.util.masked
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class BookshelfService(
@@ -102,6 +103,7 @@ class BookshelfService(
         return savedBookshelf
     }
 
+    @Transactional
     fun deleteBookshelf(publicId: String): Either<BookshelfError, Long> {
         val bookshelf =
             bookshelfRepository.findByPublicId(publicId)

--- a/backend/src/test/kotlin/io/github/tyostokarry/bookshelf/service/BookServiceTest.kt
+++ b/backend/src/test/kotlin/io/github/tyostokarry/bookshelf/service/BookServiceTest.kt
@@ -160,16 +160,17 @@ class BookServiceTest {
     inner class DeleteBook {
         @Test
         fun `deleteBook deletes successfully when found`() {
-            given(bookRepository.existsById(1L)).willReturn(true)
+            given(bookRepository.deleteByIdIfExists(1L)).willReturn(1)
 
             val result = bookService.deleteBook(1L)
 
             assertTrue(result.isRight(), "Expected Right result after update")
+            assertEquals(1L, result.getOrNull(), "Expected deleted book id to be returned")
         }
 
         @Test
         fun `deleteBook returns Left when not found`() {
-            given(bookRepository.existsById(999L)).willReturn(false)
+            given(bookRepository.deleteByIdIfExists(999L)).willReturn(0)
 
             val result = bookService.deleteBook(999L)
 


### PR DESCRIPTION
- Fix deleteBook race condition: replace existsById+deleteById with single atomic deleteByIdIfExists @Modifying query
- Fix deleteBookshelf split-transaction bug: add @Transactional to ensure book deletion and bookshelf deletion are atomic
- Fix deleteBookshelf controller: replace getOrNull()!! force-unwrap with proper Either mapping and 500 error response
- Fix deleteBook controller: add ownership check before deletion, use X_BOOKSHELF_TOKEN constant consistently
- Add INTERNAL_ERROR to ErrorCodes enum